### PR TITLE
Add SIR example model

### DIFF
--- a/gui/src/app/exampleStanies/exampleStanies.ts
+++ b/gui/src/app/exampleStanies/exampleStanies.ts
@@ -66,4 +66,76 @@ examplesStanies.push({
 })
 
 
+const SIRStan = `
+// the "susceptible-infected-recovered" model
+functions {
+  vector sir(real t, vector y, real beta, real gamma, int N) {
+    real S = y[1];
+    real I = y[2];
+    real R = y[3];
+
+    real dS_dt = -beta * I * S / N;
+    real dI_dt = beta * I * S / N - gamma * I;
+    real dR_dt = gamma * I;
+
+    return [dS_dt, dI_dt, dR_dt]';
+  }
+}
+data {
+  int<lower=1> n_days;
+  vector[3] y0;
+  real t0;
+  array[n_days] real ts;
+  int N;
+  array[n_days] int cases; // how many people are sick on day n
+}
+parameters {
+  real<lower=0> gamma;
+  real<lower=0> beta;
+  real<lower=0> phi_inv;
+}
+transformed parameters {
+  real phi = 1. / phi_inv;
+  array[n_days] vector[3] y = ode_bdf(sir, y0, t0, ts, beta, gamma, N);
+}
+model {
+  //priors
+  beta ~ normal(2, 1);
+  gamma ~ normal(0.4, 0.5);
+  phi_inv ~ exponential(5);
+
+  cases ~ poisson(y[ : , 2]);
+  // try it: a overdispersed likelihood instead
+  // cases ~ neg_binomial_2(y[,2], phi);
+}
+generated quantities {
+  // R0 is the expected number of new infections caused by a single infected individual
+  real R0 = beta / gamma;
+  real recovery_time = 1 / gamma;
+  array[n_days] real pred_cases = poisson_rng(y[ : , 2]);
+  // array[n_days] real pred_cases = neg_binomial_2_rng(y[,2], phi);
+}
+`.trim()
+
+const SIRData = {
+    "_source": "This data comes from the R package 'outbreaks'",
+    "_description": "Influenza in a boarding school in England, 1978",
+    "N": 763,
+    "cases": [3, 8, 26, 76, 225, 298, 258, 233, 189, 128, 68, 29, 14, 4],
+    "n_days": 14,
+    "ts": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
+    "t0": 0,
+    "y0": [762, 1, 0]
+}
+
+const SIRMeta = {
+    title: 'Disease transmission'
+}
+
+examplesStanies.push({
+    stan: SIRStan,
+    data: SIRData,
+    meta: SIRMeta
+})
+
 export default examplesStanies;


### PR DESCRIPTION
This adds a much more significant example model which is modeling disease transmission. The basic idea is that people are either susceptible, infected (and infectious), or recovered (and immune). A similar model is well-explained here https://mc-stan.org/users/documentation/case-studies/boarding_school_case_study.html

This model is cool because it shows off the ability of Stan to use an ODE solver as part of your model likelihood. 

With the default settings it takes ~30-40 seconds per chain, so it is definitely a decent showing of the progress bar and cancellation after #6.

This model also motivates the ability to control the sampler's arguments (typically we only run it for ~100 iterations per chain, not ~1000), and also possibly the initial values (a json similar to data)