### PR TITLE
StanSampler and misc refactor

### DIFF
--- a/gui/src/app/ApplicationBar.tsx
+++ b/gui/src/app/ApplicationBar.tsx
@@ -12,7 +12,7 @@ type Props = {
     // none
 }
 
-export const applicationBarHeight = 45
+export const applicationBarHeight = 35
 
 const logoUrl = `/stan-playground-logo.png`
 
@@ -36,8 +36,8 @@ const ApplicationBar: FunctionComponent<Props> = () => {
 
     return (
         <span>
-            <AppBar position="static" style={{height: applicationBarHeight - 10, color: 'black', background: barColor}}>
-                <Toolbar style={{minHeight: applicationBarHeight - 10}}>
+            <AppBar position="static" style={{height: applicationBarHeight, color: 'black', background: barColor}}>
+                <Toolbar style={{minHeight: applicationBarHeight}}>
                     <img src={logoUrl} alt="logo" height={27} style={{paddingBottom: 1, cursor: 'pointer'}} onClick={onHome} />
                     <div onClick={onHome} style={{cursor: 'pointer', color: titleColor}}>&nbsp;&nbsp;&nbsp;Stan Playground</div>
                     <span style={{marginLeft: 'auto'}} />

--- a/gui/src/app/FileEditor/StanFileEditor.tsx
+++ b/gui/src/app/FileEditor/StanFileEditor.tsx
@@ -138,11 +138,13 @@ const StanFileEditor: FunctionComponent<Props> = ({ fileName, fileContent, onSav
 
     const isCompiling = compileStatus === 'compiling'
 
+    const compileResultsHeight = Math.min(300, height / 3)
+
     return (
         <Splitter
             width={width}
             height={height}
-            initialPosition={height * 2 / 3}
+            initialPosition={height  - compileResultsHeight}
             direction="vertical"
         >
             <TextEditor

--- a/gui/src/app/RunPanel/RunPanel.tsx
+++ b/gui/src/app/RunPanel/RunPanel.tsx
@@ -97,7 +97,16 @@ const SamplingProgressComponent: FunctionComponent<SamplingProgressComponentProp
     return (
         <>
             <div style={{ width: "60%" }}>
-                <LinearProgressWithLabel sx={{ height: 10 }} value={progress} />
+                <LinearProgressWithLabel
+                    sx={{
+                        height: 10,
+                        // https://stackoverflow.com/a/73009519
+                        "& .MuiLinearProgress-bar": {
+                            transition: 'none'
+                        }
+                    }}
+                    value={progress}
+                />
             </div>
             <div>
                 Chain {report.chain} Iteration: {report.iteration} / {report.totalIterations} ({report.warmup ? 'Warmup' : 'Sampling'})

--- a/gui/src/app/RunPanel/RunPanel.tsx
+++ b/gui/src/app/RunPanel/RunPanel.tsx
@@ -19,7 +19,6 @@ type RunPanelProps = {
 const numChains = 4;
 
 const RunPanel: FunctionComponent<RunPanelProps> = ({ width, height, sampler, data, dataIsSaved }) => {
-
     const [runStatus, setRunStatus] = useState<StanSamplerStatus>('');
     const [errorMessage, setErrorMessage] = useState<string>('');
 
@@ -42,7 +41,9 @@ const RunPanel: FunctionComponent<RunPanelProps> = ({ width, height, sampler, da
         return (
             () => {
                 canceled = true;
-                sampler.cancel();
+                if (sampler.status === 'sampling') {
+                    sampler.cancel();
+                }
             }
         )
     }, [sampler]);

--- a/gui/src/app/RunPanel/RunPanel.tsx
+++ b/gui/src/app/RunPanel/RunPanel.tsx
@@ -6,6 +6,7 @@ import { FunctionComponent, useCallback, useEffect, useState } from 'react';
 
 import StanSampler, { StanSamplerStatus } from '../StanSampler/StanSampler';
 import { Progress } from '../tinystan/Worker';
+import { defaultSamplerParams } from '../tinystan';
 
 type RunPanelProps = {
     width: number;
@@ -51,7 +52,7 @@ const RunPanel: FunctionComponent<RunPanelProps> = ({ width, height, sampler, da
         setErrorMessage('');
         setProgress(undefined);
         console.log('sampling')
-        sampler.sample({data, numChains})
+        sampler.sample({...defaultSamplerParams, data, num_chains: numChains})
     }, [sampler, data]);
 
     const cancelRun = useCallback(() => {

--- a/gui/src/app/SamplerOutputView/SamplerOutputView.tsx
+++ b/gui/src/app/SamplerOutputView/SamplerOutputView.tsx
@@ -3,6 +3,7 @@ import { Download } from "@mui/icons-material"
 import { FunctionComponent, useCallback, useEffect, useMemo, useState } from "react"
 import StanSampler from "../StanSampler/StanSampler"
 import TabWidget from "../TabWidget/TabWidget"
+import { useSamplerOutput } from "../StanSampler/useStanSampler"
 
 type SamplerOutputViewProps = {
     width: number
@@ -11,28 +12,8 @@ type SamplerOutputViewProps = {
 }
 
 const SamplerOutputView: FunctionComponent<SamplerOutputViewProps> = ({width, height, sampler}) => {
-    const [draws, setDraws] = useState<number[][] | undefined>();
-    const [paramNames, setParamNames] = useState<string[] | undefined>();
+    const {draws, paramNames} = useSamplerOutput(sampler)
 
-    useEffect(() => {
-        let canceled = false;
-        sampler.onStatusChanged(() => {
-            if (canceled) return;
-            if (sampler.status === 'completed') {
-                setDraws(sampler.draws);
-                setParamNames(sampler.paramNames);
-            }
-            else {
-                setDraws(undefined)
-                setParamNames(undefined)
-            }
-        })
-        return (
-            () => {
-                canceled = true;
-            }
-        )
-    }, [sampler]);
     if (!draws || !paramNames) return (
         <span />
     )

--- a/gui/src/app/SamplerOutputView/SamplerOutputView.tsx
+++ b/gui/src/app/SamplerOutputView/SamplerOutputView.tsx
@@ -1,9 +1,9 @@
 import { SmallIconButton } from "@fi-sci/misc"
 import { Download } from "@mui/icons-material"
-import { FunctionComponent, useCallback, useEffect, useMemo, useState } from "react"
+import { FunctionComponent, useCallback, useMemo, useState } from "react"
 import StanSampler from "../StanSampler/StanSampler"
-import TabWidget from "../TabWidget/TabWidget"
 import { useSamplerOutput } from "../StanSampler/useStanSampler"
+import TabWidget from "../TabWidget/TabWidget"
 
 type SamplerOutputViewProps = {
     width: number

--- a/gui/src/app/SamplerOutputView/SamplerOutputView.tsx
+++ b/gui/src/app/SamplerOutputView/SamplerOutputView.tsx
@@ -1,0 +1,223 @@
+import { SmallIconButton } from "@fi-sci/misc"
+import { Download } from "@mui/icons-material"
+import { FunctionComponent, useCallback, useEffect, useMemo, useState } from "react"
+import StanSampler from "../StanSampler/StanSampler"
+import TabWidget from "../TabWidget/TabWidget"
+
+type SamplerOutputViewProps = {
+    width: number
+    height: number
+    sampler: StanSampler
+}
+
+const SamplerOutputView: FunctionComponent<SamplerOutputViewProps> = ({width, height, sampler}) => {
+    const [draws, setDraws] = useState<number[][] | undefined>();
+    const [paramNames, setParamNames] = useState<string[] | undefined>();
+
+    useEffect(() => {
+        let canceled = false;
+        sampler.onStatusChanged(() => {
+            if (canceled) return;
+            if (sampler.status === 'completed') {
+                setDraws(sampler.draws);
+                setParamNames(sampler.paramNames);
+            }
+            else {
+                setDraws(undefined)
+                setParamNames(undefined)
+            }
+        })
+        return (
+            () => {
+                canceled = true;
+                sampler.cancel();
+            }
+        )
+    }, [sampler]);
+    if (!draws || !paramNames) return (
+        <span />
+    )
+    return (
+        <DrawsDisplay
+            width={width}
+            height={height}
+            draws={draws}
+            paramNames={paramNames}
+        />
+    )
+}
+
+type DrawsDisplayProps = {
+    width: number,
+    height: number,
+    draws: number[][],
+    paramNames: string[]
+}
+
+const tabs = [
+    {
+        id: 'summary',
+        label: 'Summary',
+        title: 'Summary view',
+        closeable: false
+    },
+    {
+        id: 'draws',
+        label: 'Draws',
+        title: 'Draws view',
+        closeable: false
+    }
+]
+
+const DrawsDisplay: FunctionComponent<DrawsDisplayProps> = ({ width, height, draws, paramNames }) => {
+
+    const [currentTabId, setCurrentTabId] = useState('summary');
+
+    const means: { [k: string]: number } = {};
+
+    for (const [i, element] of paramNames.entries()) {
+        let sum = 0;
+        for (const draw of draws[i]) {
+            sum += draw;
+        }
+        means[element] = sum / draws[i].length;
+    }
+
+    return (
+        <TabWidget
+            width={width}
+            height={height}
+            tabs={tabs}
+            currentTabId={currentTabId}
+            setCurrentTabId={setCurrentTabId}
+        >
+            <SummaryView
+                draws={draws}
+                paramNames={paramNames}
+            />
+            <DrawsView
+                width={0}
+                height={0}
+                draws={draws}
+                paramNames={paramNames}
+            />
+        </TabWidget>
+    )
+}
+
+type SummaryViewProps = {
+    draws: number[][],
+    paramNames: string[]
+}
+
+const SummaryView: FunctionComponent<SummaryViewProps> = ({ draws, paramNames }) => {
+    const {means} = useMemo(() => {
+        const means: { [k: string]: number } = {};
+        for (const [i, element] of paramNames.entries()) {
+            let sum = 0;
+            for (const draw of draws[i]) {
+                sum += draw;
+            }
+            means[element] = sum / draws[i].length;
+        }
+        return {means};
+    }, [draws, paramNames]);
+
+    return (
+        <table className="scientific-table">
+            <thead>
+                <tr>
+                    <th>Parameter</th>
+                    <th>Mean</th>
+                </tr>
+            </thead>
+            <tbody>
+                {Object.entries(means).map(([name, mean]) => (
+                    <tr key={name}>
+                        <td>{name}</td>
+                        <td>{mean}</td>
+                    </tr>
+                ))}
+            </tbody>
+        </table>
+    )
+}
+
+type DrawsViewProps = {
+    width: number
+    height: number
+    draws: number[][],
+    paramNames: string[]
+}
+
+const DrawsView: FunctionComponent<DrawsViewProps> = ({ width, height, draws, paramNames }) => {
+    const [abbreviatedToNumRows, setAbbreviatedToNumRows] = useState<number | undefined>(300);
+    const draws2 = useMemo(() => {
+        if (abbreviatedToNumRows === undefined) return draws;
+        return draws.map(draw => draw.slice(0, abbreviatedToNumRows));
+    }, [draws, abbreviatedToNumRows]);
+    const handleExportToCsv = useCallback(() => {
+        const csvText = prepareCsvText(draws, paramNames);
+        downloadTextFile(csvText, 'draws.csv');
+    }, [draws, paramNames]);
+    return (
+        <div style={{position: 'absolute', width, height, overflow: 'auto'}}>
+            <SmallIconButton
+                icon={<Download />}
+                label="Export to .csv"
+                onClick={handleExportToCsv}
+            />
+            <table className="draws-table">
+                <thead>
+                    <tr>
+                        {
+                            paramNames.map((name, i) => (
+                                <th key={i}>{name}</th>
+                            ))
+                        }
+                    </tr>
+                </thead>
+                <tbody>
+                    {
+                        draws2[0].map((_, i) => (
+                            <tr key={i}>
+                                {
+                                    draws.map((draw, j) => (
+                                        <td key={j}>{draw[i]}</td>
+                                    ))
+                                }
+                            </tr>
+                        ))
+                    }
+                </tbody>
+            </table>
+            {
+                abbreviatedToNumRows !== undefined && abbreviatedToNumRows < draws[0].length && (
+                    <div style={{background: 'white', padding: 5}}>
+                        <button onClick={() => {
+                            setAbbreviatedToNumRows(x => (x || 0) + 300)
+                        }}>Show more</button>
+                    </div>
+                )
+            }
+        </div>
+    )
+}
+
+const prepareCsvText = (draws: number[][], paramNames: string[]) => {
+    const lines = draws[0].map((_, i) => {
+        return paramNames.map((_, j) => draws[j][i]).join(',')
+    })
+    return [paramNames.join(','), ...lines].join('\n')
+}
+
+const downloadTextFile = (text: string, filename: string) => {
+    const blob = new Blob([text], {type: 'text/plain'});
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+}
+
+export default SamplerOutputView

--- a/gui/src/app/SamplerOutputView/SamplerOutputView.tsx
+++ b/gui/src/app/SamplerOutputView/SamplerOutputView.tsx
@@ -30,7 +30,6 @@ const SamplerOutputView: FunctionComponent<SamplerOutputViewProps> = ({width, he
         return (
             () => {
                 canceled = true;
-                sampler.cancel();
             }
         )
     }, [sampler]);

--- a/gui/src/app/StanSampler/StanSampler.ts
+++ b/gui/src/app/StanSampler/StanSampler.ts
@@ -49,6 +49,18 @@ class StanSampler {
     }
     sample(sampleConfig: SamplerParams) {
         if (!this.#worker) return
+        if (this.#status === '') {
+            console.warn('Model not loaded yet')
+            return
+        }
+        if (this.#status === 'sampling') {
+            console.warn('Already sampling')
+            return
+        }
+        if (this.#status === 'loading') {
+            console.warn('Model not loaded yet')
+            return
+        }
         this.#draws = [];
         this.#paramNames = [];
         this.#worker
@@ -63,13 +75,19 @@ class StanSampler {
         this.#onStatusChangedCallbacks.push(callback);
     }
     cancel() {
-        this.terminate();
-        this._initialize();
+        if (this.#status === 'sampling') {
+            this.#worker && this.#worker.terminate();
+            this._initialize();
+        }
+        else {
+            console.warn('Nothing to cancel')
+        }
     }
     terminate() {
         if (!this.#worker) return;
         this.#worker.terminate();
         this.#worker = undefined;
+        this.#status = '';
     }
     get draws() {
         return this.#draws;

--- a/gui/src/app/StanSampler/StanSampler.ts
+++ b/gui/src/app/StanSampler/StanSampler.ts
@@ -1,0 +1,85 @@
+import { Progress, Replies, Requests } from '../tinystan/Worker';
+import StanWorker from '../tinystan/Worker?worker';
+
+export type StanSamplerStatus = '' | 'loading' | 'loaded' | 'sampling' | 'completed' | 'failed';
+
+class StanSampler {
+    #worker: Worker | undefined;
+    #status: StanSamplerStatus = '';
+    #errorMessage: string = '';
+    #onProgressCallbacks: ((progress: Progress) => void)[] = [];
+    #onStatusChangedCallbacks: (() => void)[] = [];
+    #draws: number[][] = [];
+    #paramNames: string[] = [];
+    constructor(private compiledUrl: string) {
+        this._initialize()
+    }
+    _initialize() {
+        this.#worker = new StanWorker
+        this.#status = 'loading'
+        this.#worker.onmessage = (e) => {
+            const purpose: Replies = e.data.purpose;
+            switch (purpose) {
+                case Replies.Progress: {
+                    this.#onProgressCallbacks.forEach(callback => callback(e.data.report));
+                    break;
+                }
+                case Replies.ModelLoaded: {
+                    this.#status = 'loaded';
+                    this.#onStatusChangedCallbacks.forEach(cb => cb())
+                    break;
+                }
+                case Replies.SampleReturn: {
+                    if (e.data.error) {
+                        this.#errorMessage = e.data.error;
+                        this.#status = 'failed';
+                        this.#onStatusChangedCallbacks.forEach(cb => cb())
+                    } else {
+                        this.#draws = e.data.draws;
+                        this.#paramNames = e.data.paramNames;
+                        this.#status = 'completed';
+                        this.#onStatusChangedCallbacks.forEach(cb => cb())
+                    }
+                    break;
+                }
+            }
+        }
+        this.#worker.postMessage({ purpose: Requests.Load, url: this.compiledUrl });
+    }
+    sample(a: {data: any, numChains: number}) {
+        if (!this.#worker) return
+        const { data, numChains } = a;
+        this.#draws = [];
+        this.#paramNames = [];
+        this.#worker
+            .postMessage({ purpose: Requests.Sample, sampleConfig: { data, chains: numChains } });
+        this.#status = 'sampling';
+        this.#onStatusChangedCallbacks.forEach(cb => cb())
+    }
+    onProgress(callback: (progress: Progress) => void) {
+        this.#onProgressCallbacks.push(callback);
+    }
+    onStatusChanged(callback: () => void) {
+        this.#onStatusChangedCallbacks.push(callback);
+    }
+    cancel() {
+        if (!this.#worker) return;
+        this.#worker.terminate();
+        this.#worker = undefined;
+        this._initialize();
+    }
+    get draws() {
+        return this.#draws;
+    }
+    get paramNames() {
+        return this.#paramNames;
+    }
+    get status() {
+        return this.#status;
+    }
+    get errorMessage() {
+        return this.#errorMessage;
+    }
+}
+
+export default StanSampler

--- a/gui/src/app/StanSampler/StanSampler.ts
+++ b/gui/src/app/StanSampler/StanSampler.ts
@@ -17,7 +17,7 @@ class StanSampler {
         this._initialize()
     }
 
-    static create(compiledUrl: string): { sampler: StanSampler, cleanup: () => void } {
+    static __unsafe_create(compiledUrl: string): { sampler: StanSampler, cleanup: () => void } {
         const sampler = new StanSampler(compiledUrl);
         const cleanup = () => {
             sampler.#worker && sampler.#worker.terminate();

--- a/gui/src/app/StanSampler/StanSampler.ts
+++ b/gui/src/app/StanSampler/StanSampler.ts
@@ -1,3 +1,4 @@
+import { SamplerParams } from '../tinystan';
 import { Progress, Replies, Requests } from '../tinystan/Worker';
 import StanWorker from '../tinystan/Worker?worker';
 
@@ -46,13 +47,12 @@ class StanSampler {
         }
         this.#worker.postMessage({ purpose: Requests.Load, url: this.compiledUrl });
     }
-    sample(a: {data: any, numChains: number}) {
+    sample(sampleConfig: SamplerParams) {
         if (!this.#worker) return
-        const { data, numChains } = a;
         this.#draws = [];
         this.#paramNames = [];
         this.#worker
-            .postMessage({ purpose: Requests.Sample, sampleConfig: { data, chains: numChains } });
+            .postMessage({ purpose: Requests.Sample, sampleConfig});
         this.#status = 'sampling';
         this.#onStatusChangedCallbacks.forEach(cb => cb())
     }

--- a/gui/src/app/StanSampler/StanSampler.ts
+++ b/gui/src/app/StanSampler/StanSampler.ts
@@ -63,10 +63,13 @@ class StanSampler {
         this.#onStatusChangedCallbacks.push(callback);
     }
     cancel() {
+        this.terminate();
+        this._initialize();
+    }
+    terminate() {
         if (!this.#worker) return;
         this.#worker.terminate();
         this.#worker = undefined;
-        this._initialize();
     }
     get draws() {
         return this.#draws;

--- a/gui/src/app/StanSampler/useStanSampler.ts
+++ b/gui/src/app/StanSampler/useStanSampler.ts
@@ -9,14 +9,13 @@ const useStanSampler = (compiledMainJsUrl: string | undefined) => {
             setSampler(undefined);
             return;
         }
-        const s = new StanSampler(compiledMainJsUrl);
-        setSampler(s);
-        return () => {
-            s.terminate();
-        }
+        const { sampler, cleanup: destructor } = StanSampler.create(compiledMainJsUrl);
+        setSampler(sampler);
+        return destructor;
+
     }, [compiledMainJsUrl])
 
-    return {sampler}
+    return { sampler }
 }
 
 export const useSamplerStatus = (sampler: StanSampler | undefined) => {

--- a/gui/src/app/StanSampler/useStanSampler.ts
+++ b/gui/src/app/StanSampler/useStanSampler.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
-import StanSampler from "./StanSampler";
+import StanSampler, { StanSamplerStatus } from "./StanSampler";
+import { Progress } from "../tinystan/Worker";
 
 const useStanSampler = (compiledMainJsUrl: string | undefined) => {
     const [sampler, setSampler] = useState<StanSampler | undefined>(undefined);
@@ -16,6 +17,77 @@ const useStanSampler = (compiledMainJsUrl: string | undefined) => {
     }, [compiledMainJsUrl])
 
     return {sampler}
+}
+
+export const useSamplerStatus = (sampler: StanSampler | undefined) => {
+    const [status, setStatus] = useState<StanSamplerStatus>('');
+    const [errorMessage, setErrorMessage] = useState<string>('');
+    useEffect(() => {
+        if (!sampler) return;
+        let canceled = false;
+        setStatus(sampler.status);
+        const cb = () => {
+            if (canceled) return;
+            setStatus(sampler.status);
+            if (sampler.status === 'failed') {
+                setErrorMessage(sampler.errorMessage);
+            }
+        }
+        sampler.onStatusChanged(cb);
+        return () => {
+            canceled = true;
+        }
+    }, [sampler]);
+    return { status, errorMessage };
+}
+
+export const useSamplerProgress = (sampler: StanSampler | undefined) => {
+    const [progress, setProgress] = useState<Progress | undefined>(undefined);
+    useEffect(() => {
+        if (!sampler) return;
+        let canceled = false;
+        const cb = (progress: Progress) => {
+            if (canceled) return;
+            setProgress(progress);
+        }
+        sampler.onProgress(cb);
+        return () => {
+            canceled = true;
+        }
+    }, [sampler]);
+    return progress;
+}
+
+export const useSamplerOutput = (sampler: StanSampler | undefined) => {
+    const [draws, setDraws] = useState<number[][] | undefined>();
+    const [paramNames, setParamNames] = useState<string[] | undefined>();
+
+    useEffect(() => {
+        let canceled = false;
+        if (!sampler) {
+            setDraws(undefined);
+            setParamNames(undefined);
+            return;
+        }
+        sampler.onStatusChanged(() => {
+            if (canceled) return;
+            if (sampler.status === 'completed') {
+                setDraws(sampler.draws);
+                setParamNames(sampler.paramNames);
+            }
+            else {
+                setDraws(undefined)
+                setParamNames(undefined)
+            }
+        })
+        return (
+            () => {
+                canceled = true;
+            }
+        )
+    }, [sampler]);
+
+    return { draws, paramNames }
 }
 
 export default useStanSampler;

--- a/gui/src/app/StanSampler/useStanSampler.ts
+++ b/gui/src/app/StanSampler/useStanSampler.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from "react";
+import StanSampler from "./StanSampler";
+
+const useStanSampler = (compiledMainJsUrl: string | undefined) => {
+    const [sampler, setSampler] = useState<StanSampler | undefined>(undefined);
+    useEffect(() => {
+        if (!compiledMainJsUrl) {
+            setSampler(undefined);
+            return;
+        }
+        const s = new StanSampler(compiledMainJsUrl);
+        setSampler(s);
+        return () => {
+            s.terminate();
+        }
+    }, [compiledMainJsUrl])
+
+    return {sampler}
+}
+
+export default useStanSampler;

--- a/gui/src/app/StanSampler/useStanSampler.ts
+++ b/gui/src/app/StanSampler/useStanSampler.ts
@@ -9,7 +9,7 @@ const useStanSampler = (compiledMainJsUrl: string | undefined) => {
             setSampler(undefined);
             return;
         }
-        const { sampler, cleanup: destructor } = StanSampler.create(compiledMainJsUrl);
+        const { sampler, cleanup: destructor } = StanSampler.__unsafe_create(compiledMainJsUrl);
         setSampler(sampler);
         return destructor;
 
@@ -43,6 +43,7 @@ export const useSamplerStatus = (sampler: StanSampler | undefined) => {
 export const useSamplerProgress = (sampler: StanSampler | undefined) => {
     const [progress, setProgress] = useState<Progress | undefined>(undefined);
     useEffect(() => {
+        setProgress(undefined);
         if (!sampler) return;
         let canceled = false;
         const cb = (progress: Progress) => {

--- a/gui/src/app/TabWidget/TabWidget.tsx
+++ b/gui/src/app/TabWidget/TabWidget.tsx
@@ -12,7 +12,7 @@ type Props = {
     }[]
     currentTabId: string | undefined
     setCurrentTabId: (id: string) => void
-    onCloseTab: (id: string) => void
+    onCloseTab?: (id: string) => void
     width: number
     height: number
 }

--- a/gui/src/app/TabWidget/TabWidgetTabBar.tsx
+++ b/gui/src/app/TabWidget/TabWidgetTabBar.tsx
@@ -12,7 +12,7 @@ type Props = {
     }[]
     currentTabIndex: number | undefined
     onCurrentTabIndexChanged: (i: number) => void
-    onCloseTab: (id: string) => void
+    onCloseTab?: (id: string) => void
 }
 
 const TabWidgetTabBar: FunctionComponent<Props> = ({ tabs, currentTabIndex, onCurrentTabIndexChanged, onCloseTab }) => {
@@ -39,7 +39,7 @@ const TabWidgetTabBar: FunctionComponent<Props> = ({ tabs, currentTabIndex, onCu
                             ) : <span />
                         }
                         <span style={{textTransform: 'none', fontSize: 14}}>{tab.label}</span>
-                        &nbsp;&nbsp;{tab.closeable && <span onClick={() => {onCloseTab(tab.id)}}>✕</span>}
+                        &nbsp;&nbsp;{tab.closeable && onCloseTab && <span onClick={() => {onCloseTab(tab.id)}}>✕</span>}
                     </span>
                 } sx={{minHeight: 0, height: 0, fontSize: 12}} />
             ))}

--- a/gui/src/app/pages/HomePage/HomePage.tsx
+++ b/gui/src/app/pages/HomePage/HomePage.tsx
@@ -105,7 +105,7 @@ const HomePage: FunctionComponent<Props> = ({ width, height }) => {
         const s = new StanSampler(compileMainJsUrl);
         setSampler(s);
         return () => {
-            s.cancel();
+            s.terminate();
         }
     }, [compileMainJsUrl])
 

--- a/gui/src/app/tinystan/index.ts
+++ b/gui/src/app/tinystan/index.ts
@@ -88,7 +88,7 @@ export interface SamplerParams {
   num_threads: number;
 }
 
-const defaultSamplerParams: SamplerParams = {
+export const defaultSamplerParams: SamplerParams = {
   data: "",
   num_chains: 4,
   seed: null,

--- a/gui/src/draws-table-2.css
+++ b/gui/src/draws-table-2.css
@@ -1,4 +1,4 @@
-.nwb-table-2 {
+.draws-table-2 {
     border-collapse: separate;
     border-spacing: 2px 0px;
     font-size: 0.75em;
@@ -7,7 +7,7 @@
     margin: 0px 0;
 }
 
-.nwb-table-2 td {
+.draws-table-2 td {
     white-space: nowrap;
     text-overflow: ellipsis;
     min-width: 100px;
@@ -16,35 +16,35 @@
     padding: 30px;
 }
 
-.nwb-table-2 thead tr {
+.draws-table-2 thead tr {
     background-color: #009879;
     color: #ffffff;
     text-align: left;
 }
 
-.nwb-table-2 th,
-.nwb-table-2 td {
+.draws-table-2 th,
+.draws-table-2 td {
     padding: 2px 2px;
 }
 
-.nwb-table-2 tbody tr {
+.draws-table-2 tbody tr {
     border-bottom: thin solid #dddddd;
 }
 
-.nwb-table-2 tbody tr:nth-of-type(even) {
+.draws-table-2 tbody tr:nth-of-type(even) {
     background-color: #c5fad0;
 }
 
-.nwb-table-2 tbody tr:last-of-type {
+.draws-table-2 tbody tr:last-of-type {
     border-bottom: 2px solid #009879;
 }
 
-.nwb-table-2 tbody tr:hover {
+.draws-table-2 tbody tr:hover {
     background-color: #ededed;
     transition: background-color 0.3s ease;
 }
 
-.nwb-table-2 thead tr {
+.draws-table-2 thead tr {
     position: sticky;
     top: 0;
 }

--- a/gui/src/draws-table.css
+++ b/gui/src/draws-table.css
@@ -1,4 +1,4 @@
-.nwb-table {
+.draws-table {
     width: 100%;
     border-collapse: collapse;
     font-size: 0.75em;
@@ -7,41 +7,41 @@
     margin: 0px 0;
 }
 
-.nwb-table td {
+.draws-table td {
     word-break: break-all;
     max-width: 250px;
     overflow: hidden;
 }
 
-.nwb-table thead tr {
+.draws-table thead tr {
     background-color: #009879;
     color: #ffffff;
     text-align: left;
 }
 
-.nwb-table th,
-.nwb-table td {
+.draws-table th,
+.draws-table td {
     padding: 2px 2px;
 }
 
-.nwb-table tbody tr {
+.draws-table tbody tr {
     border-bottom: thin solid #dddddd;
 }
 
-.nwb-table tbody tr:nth-of-type(even) {
+.draws-table tbody tr:nth-of-type(even) {
     background-color: #f3f3f3;
 }
 
-.nwb-table tbody tr:last-of-type {
+.draws-table tbody tr:last-of-type {
     border-bottom: 2px solid #009879;
 }
 
-.nwb-table tbody tr:hover {
+.draws-table tbody tr:hover {
     background-color: #ededed;
     transition: background-color 0.3s ease;
 }
 
-.nwb-table thead tr {
+.draws-table thead tr {
     position: sticky;
     top: 0;
 }

--- a/gui/src/main.tsx
+++ b/gui/src/main.tsx
@@ -4,8 +4,8 @@ import * as ReactDOM from 'react-dom/client';
 import App from './app/App';
 import './localStyles.css';
 import './index.css';
-import './nwb-table.css';
-import './nwb-table-2.css';
+import './draws-table.css';
+import './draws-table-2.css';
 import './scientific-table.css';
 import './table1.css'
 


### PR DESCRIPTION
@WardBrian @jsoules 

Description of changes in this PR

(this branch has been deployed here: https://stan-playground.vercel.app/)

* New StanSampler class that manages the worker as an internal variable and also manages the state and the sampling outputs
* Lifted the sampler state up to the HomePage (so that it is not just confined to the RunPanel)
* Split the RunPanel into two parts: RunPanel and SamplerOutputView
* SamplerOutputView is a tab widget that shows a Summary tab and a Draws tab.
* The Summary tab shows the means of the variables
* The Draws tab shows a table of all the draws
* There is an export to .csv button on the draws table
* Some adjustments on the layout (default sizes of panels, etc)