### PR TITLE
Basic support for calling Pathfinder

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,7 +42,7 @@ COPY make/js /app/tinystan/make/js
 # Build a test model
 RUN cd tinystan && \
     echo 'include make/js' >> Makefile && \
-    emmake make test_models/bernoulli/bernoulli.js -j2 && \
+    emmake make test_models/bernoulli/bernoulli.js -j4 && \
     emstrip test_models/bernoulli/bernoulli.wasm
 
 RUN pip install fastapi

--- a/docker/make/local
+++ b/docker/make/local
@@ -11,11 +11,10 @@ LDLIBS_TBB ?= -ltbb
 
 # could also uses -fexceptions which is more compatible, but slower
 CXXFLAGS+=-fwasm-exceptions
-CXXFLAGS+=-g
 
-LDFLAGS+=-sMODULARIZE -sEXPORT_NAME=createModule -sEXPORT_ES6 -sENVIRONMENT=web
+LDFLAGS+=-sMODULARIZE -sEXPORT_NAME=createModule -sEXPORT_ES6 -sENVIRONMENT=web -sINCOMING_MODULE_JS_API=print,printErr
 LDFLAGS+=-sEXIT_RUNTIME=1 -sALLOW_MEMORY_GROWTH=1
 # Functions we want. Can add more, with a prepended _, from tinystan.h
-EXPORTS=_malloc,_free,_tinystan_api_version,_tinystan_create_model,_tinystan_destroy_error,_tinystan_destroy_model,_tinystan_get_error_message,_tinystan_get_error_type,_tinystan_model_num_free_params,_tinystan_model_param_names,_tinystan_sample,_tinystan_separator_char,_tinystan_stan_version
+EXPORTS=_malloc,_free,_tinystan_api_version,_tinystan_create_model,_tinystan_destroy_error,_tinystan_destroy_model,_tinystan_get_error_message,_tinystan_get_error_type,_tinystan_model_num_free_params,_tinystan_model_param_names,_tinystan_sample,_tinystan_pathfinder,_tinystan_separator_char,_tinystan_stan_version
 LDFLAGS+=-sEXPORTED_FUNCTIONS=$(EXPORTS) -sEXPORTED_RUNTIME_METHODS=stringToUTF8,getValue,UTF8ToString,lengthBytesUTF8
 

--- a/gui/src/app/StanSampler/StanSampler.ts
+++ b/gui/src/app/StanSampler/StanSampler.ts
@@ -41,7 +41,7 @@ class StanSampler {
                     this.#onStatusChangedCallbacks.forEach(cb => cb())
                     break;
                 }
-                case Replies.SampleReturn: {
+                case Replies.StanReturn: {
                     if (e.data.error) {
                         this.#errorMessage = e.data.error;
                         this.#status = 'failed';

--- a/gui/src/app/tinystan/Worker.ts
+++ b/gui/src/app/tinystan/Worker.ts
@@ -3,11 +3,12 @@ import StanModel from ".";
 export enum Requests {
     Load = "load",
     Sample = "sample",
+    Pathfinder = "pathfinder",
 }
 
 export enum Replies {
     ModelLoaded = "modelLoaded",
-    SampleReturn = "sampleReturn",
+    StanReturn = "stanReturn",
     Progress = "progress",
 }
 
@@ -62,15 +63,29 @@ onmessage = function (e) {
         }
         case Requests.Sample: {
             if (!model) {
-                postMessage({ purpose: Replies.SampleReturn, error: "Model not loaded yet!" })
+                postMessage({ purpose: Replies.StanReturn, error: "Model not loaded yet!" })
                 return;
             }
             try {
                 const { paramNames, draws } = model.sample(e.data.sampleConfig);
                 // TODO? use an ArrayBuffer so we can transfer without serialization cost
-                postMessage({ purpose: Replies.SampleReturn, draws, paramNames, error: null });
+                postMessage({ purpose: Replies.StanReturn, draws, paramNames, error: null });
             } catch (e: any) {
-                postMessage({ purpose: Replies.SampleReturn, error: e.toString() })
+                postMessage({ purpose: Replies.StanReturn, error: e.toString() })
+            }
+            break;
+        }
+        case Requests.Pathfinder: {
+            if (!model) {
+                postMessage({ purpose: Replies.StanReturn, error: "Model not loaded yet!" })
+                return;
+            }
+            try {
+                const { draws, paramNames } = model.pathfinder(e.data.pathfinderConfig);
+                // TODO? use an ArrayBuffer so we can transfer without serialization cost
+                postMessage({ purpose: Replies.StanReturn, draws, paramNames, error: null });
+            } catch (e: any) {
+                postMessage({ purpose: Replies.StanReturn, error: e.toString() })
             }
             break;
         }


### PR DESCRIPTION
This adds the basics to allow calling Pathfinder:

- Request the `_tinystan_pathfinder` function in the build config
- Add a function to the tinystan wrapper to call this, re-using a lot of the same machinery as the sampler
- Add a new `Request` variant in the worker for requesting Pathfinder be run
   - I decided for now to have the return message be the same - we could obviously change this if we wanted


This this does not do:

- Any UI for calling it instead of sampling (to test, I just replaced the call to the sampler with the call to pathfinder in our existing UI). It also has its own set of control flags we'd want to expose, like #16 

- Any way to wire the results of Pathfinder up as initial values for sampling (needlessly hard, but probably worthwhile eventually)

 