### PR TITLE
Simplify docker image with newer tinystan

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,21 +28,21 @@ RUN mkdir oneTBB/build && cd oneTBB/build && \
     -DTBB_TEST=OFF \
     -DEMSCRIPTEN_WITHOUT_PTHREAD=true \
     -DCMAKE_INSTALL_PREFIX=/app/oneTBB/install/ && \
-    cmake --build . -j2 && \
+    cmake --build . -j$(nproc) && \
     cmake --install .
 
-# Clone the TinyStan repository and checkout a specific commit 5/9/2024
-RUN git clone https://github.com/WardBrian/tinystan.git --recursive --shallow-submodules && \
-cd tinystan && git checkout "1deb4e5f68dd83cb523cf83073813a9ae1507cad"
+# Clone the TinyStan repository and checkout a specific commit
+RUN git clone https://github.com/WardBrian/tinystan.git && \
+    cd tinystan && \
+    git checkout "e1e675ea21873e3365bb0d54a843f4c0f54bf6a8" && \
+    git submodule update --init --recursive
 
 # Copy the local configuration file for TinyStan
 COPY make/local /app/tinystan/make/local
-COPY make/js /app/tinystan/make/js
 
 # Build a test model
 RUN cd tinystan && \
-    echo 'include make/js' >> Makefile && \
-    emmake make test_models/bernoulli/bernoulli.js -j4 && \
+    emmake make test_models/bernoulli/bernoulli.js -j$(nproc) && \
     emstrip test_models/bernoulli/bernoulli.wasm
 
 RUN pip install fastapi

--- a/docker/make/js
+++ b/docker/make/js
@@ -1,2 +1,0 @@
-%.js : %.o $(TINYSTAN_O) $(SUNDIALS_TARGETS) $(MPI_TARGETS) $(TBB_TARGETS)
-	$(LINK.cpp) -lm -o $(patsubst %.o, %.js, $(subst \,/,$<)) $(subst \,/,$*.o) $(TINYSTAN_O) $(LDLIBS) $(SUNDIALS_TARGETS) $(MPI_TARGETS) $(TBB_TARGETS)


### PR DESCRIPTION
TinyStan has the `.js` target now, so we don't need the `make/js` file. 