### PR TITLE
Run build in current job folder

### DIFF
--- a/docker/stan-wasm-server/logic/compilation.py
+++ b/docker/stan-wasm-server/logic/compilation.py
@@ -25,18 +25,6 @@ def make_canonical_model_dir(src_file: Path):
     return model_dir.absolute()
 
 
-# TODO: Remove this and run directly from the canonical model directory
-def copy_compilation_outputs(*, model_dir: Path, job_dir: Path):
-    todos = []
-    for f in COMPILATION_OUTPUTS:
-        src = model_dir / f
-        dest = job_dir / f
-        if not src.exists():
-            raise FileNotFoundError(f"File {src} does not exist.")
-        todos.append((src, dest))
-    for (src, dest) in todos:
-        copy2(src, dest)
-
 async def compile_and_cache(*, job_id: str, model_dir: Path, tinystan_dir: Path):
 
     # if there's a cache hit, make sure any copying is already complete,
@@ -56,7 +44,8 @@ async def compile_and_cache(*, job_id: str, model_dir: Path, tinystan_dir: Path)
             for file in COMPILATION_OUTPUTS:
                 copy2(job_dir / file, model_dir / file)
         # otherwise, just wait for the other thread's version to be
-        # copied. We wasted some time, but that's ultimately okay
+        # copied. We do not need to copy, because their version will
+        # be equivalent; we wasted some time, but that's ultimately okay
         else:
             wait_until_free(model_dir)
 

--- a/docker/stan-wasm-server/logic/compilation.py
+++ b/docker/stan-wasm-server/logic/compilation.py
@@ -1,16 +1,15 @@
 import asyncio
 from hashlib import sha1
-from shutil import copy2, rmtree
+from shutil import copy2
 from pathlib import Path
 
-from .definitions import CompilationStatus
-from .locking import get_nonce, acquire_compilation_lock, release_compilation_lock
+from .locking import compilation_output_lock, wait_until_free
 from .exceptions import StanPlaygroundCompilationException, StanPlaygroundCompilationTimeoutException
-
+from .compilation_job_mgmt import get_job_source_file, get_compilation_job_dir
+from .file_validation.compilation_files import COMPILATION_OUTPUTS
 
 COMPILED_MODELS_BASE_PATH = Path('/compiled_models')
 COMPILATION_TIMEOUT = 60 * 5
-COMPILATION_OUTPUTS = ['main.js', 'main.wasm']
 
 
 def _compute_stan_program_hash(program_file: Path):
@@ -38,60 +37,46 @@ def copy_compilation_outputs(*, model_dir: Path, job_dir: Path):
     for (src, dest) in todos:
         copy2(src, dest)
 
+async def compile_and_cache(*, job_id: str, model_dir: Path, tinystan_dir: Path):
+    if all((model_dir / x).exists() for x in COMPILATION_OUTPUTS):
+        wait_until_free(model_dir)
+        return
 
-# TODO: This will change substantially if we compile in the job directory directly.
-async def try_compile_stan_program(*, job_dir: Path, model_dir: Path, tinystan_dir: Path, preserve_on_fail = False) -> tuple[CompilationStatus, str]:
+    await compile_stan_program(job_id=job_id, tinystan_dir=tinystan_dir)
+
+    job_dir = get_compilation_job_dir(job_id)
+
+    with compilation_output_lock(model_dir) as exclusive:
+        if exclusive:
+            for file in COMPILATION_OUTPUTS:
+                copy2(job_dir / file, model_dir / file)
+        else:
+            wait_until_free(model_dir)
+
+
+
+async def compile_stan_program(*, job_id: str, tinystan_dir: Path, ):
     """Attempts to compile the submitted stan program (if uncompiled) and copy the compiled outputs to the job directory.
 
     Args:
         job_dir: Job directory for the incoming job
-        model_dir: Canonical model directory for the submitted code.
         tinystan_dir: Location of the tinystan installation (with compilation tools)
-        preserve_on_fail: May be set to True for debugging purposes, in the event of problematic models. Defaults to False.
 
-    Returns:
-        A Tuple of the compilation status and the error message, if any.
     """
-    try:
-        nonce = get_nonce()
-        if acquire_compilation_lock(model_dir, nonce):
-            await compile_model_if_uncompiled(job_dir=job_dir, model_dir=model_dir, tinystan_dir=tinystan_dir, preserve_on_fail=preserve_on_fail)
-            copy_compilation_outputs(model_dir=model_dir, job_dir=job_dir)
-            return (CompilationStatus.COMPLETED, '')
-        # NOTE: Could also include job ID in lockfile and report that here
-        return (CompilationStatus.RUNNING, '')
-    except Exception as e:
-        return (CompilationStatus.FAILED, str(e))
-    finally:
-        release_compilation_lock(model_dir, nonce)
-
-
-async def compile_model_if_uncompiled(*, job_dir: Path, model_dir: Path, tinystan_dir: Path, preserve_on_fail = False):
     # Invariant: if compilation output files exist, we should never re-create them, because they either
     # represent the successful compilation of a semantically identical source file
     # or they're leftovers from a prior failed run that intentionally preserved them.
     # So step 1 is check if compilation outputs exist and return if they do.
     # NOTE: preserve_on_fail is implemented to support a debug build, if there are particular model failures
     # that need to be investigated. At present it should always be False.
-    if all((model_dir / x).exists() for x in COMPILATION_OUTPUTS):
-        return
 
     try:
-        job_main = (job_dir / "main.stan").absolute()
-        model_main = (model_dir / "main.stan").absolute()
-        copy2(job_main, model_main)
-        cmd = f"emmake make {model_main.with_suffix('.js')} && emstrip {model_main.with_suffix('.wasm')}"
+        job_main = get_job_source_file(job_id)
+        cmd = f"emmake make {job_main.with_suffix('.js')} && emstrip {job_main.with_suffix('.wasm')}"
         process = await asyncio.create_subprocess_shell(cmd, cwd=tinystan_dir)
-        await asyncio.wait_for( process.communicate(), timeout=COMPILATION_TIMEOUT)
+        await asyncio.wait_for(process.wait(), timeout=COMPILATION_TIMEOUT)
     except (asyncio.TimeoutError, TimeoutError):
-        _clear_directory_if_not_preserved(model_dir, preserve_on_fail)
         raise StanPlaygroundCompilationTimeoutException()
 
     if process.returncode != 0:
-        _clear_directory_if_not_preserved(model_dir, preserve_on_fail)
         raise StanPlaygroundCompilationException(f'Failed to compile model: exit code {process.returncode}')
-
-
-def _clear_directory_if_not_preserved(model_dir: Path, preserve_on_fail: bool):
-    if not preserve_on_fail:
-        rmtree(model_dir)

--- a/docker/stan-wasm-server/logic/exceptions.py
+++ b/docker/stan-wasm-server/logic/exceptions.py
@@ -1,24 +1,65 @@
-class StanPlaygroundAuthenticationException(Exception):
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi import Request
+
+
+class StanPlaygroundException(Exception):
+    """Base exception for the Stan Playground."""
+    code: int
+    def to_message(self):
+        return str(self)
+
+    @classmethod
+    def register_handler(cls, app: FastAPI):
+        @app.exception_handler(cls)
+        async def _(request: Request, exc: cls):
+            return JSONResponse(
+                status_code=cls.code,
+                content={
+                    "message": exc.to_message()
+                }
+            )
+
+class StanPlaygroundAuthenticationException(StanPlaygroundException):
     """Raise if authentication failed."""
+    code: int = 401
 
-class StanPlaygroundCompilationException(Exception):
-    """Raise if compilation failed for non-timeout (including unknown) reasons."""
-
-class StanPlaygroundCompilationTimeoutException(Exception):
-    """Raise if compilation failed due to timeout specifically."""
-
-class StanPlaygroundInvalidJobException(Exception):
+class StanPlaygroundInvalidJobException(StanPlaygroundException):
     """Raise if an invalid job ID is requested."""
+    code: int = 400
+    def to_message(self):
+        return f"Invalid job ID {self}"
 
-class StanPlaygroundJobNotFoundException(Exception):
+class StanPlaygroundJobNotFoundException(StanPlaygroundException):
     """Raise if a job ID is valid but the job directory does not exist."""
+    code: int = 404
+    def to_message(self):
+        return f"Job {self} not found."
 
-class StanPlaygroundBadStatusException(Exception):
+class StanPlaygroundAlreadyUploaded(StanPlaygroundException):
     """Raise if a request cannot be completed due to the current job status."""
+    code: int = 409
 
-class StanPlaygroundBadNameException(Exception):
-    """Raise if a requested filename is invalid."""
-
-class StanPlaygroundInvalidFileException(Exception):
+class StanPlaygroundInvalidFileException(StanPlaygroundException):
     """Raise if a submitted file is not valid (e.g. exceeds size limits)"""
+    code: int = 400
 
+class StanPlaygroundCompilationException(StanPlaygroundException):
+    """Raise if compilation failed for non-timeout (including unknown) reasons."""
+    code: int = 422
+
+class StanPlaygroundCompilationTimeoutException(StanPlaygroundException):
+    """Raise if compilation failed due to timeout specifically."""
+    code: int = 400
+    def to_message(self):
+        return "Model compilation took too long to complete"
+
+ALL_EXCEPTIONS = [
+    StanPlaygroundAuthenticationException,
+    StanPlaygroundInvalidJobException,
+    StanPlaygroundJobNotFoundException,
+    StanPlaygroundAlreadyUploaded,
+    StanPlaygroundInvalidFileException,
+    StanPlaygroundCompilationException,
+    StanPlaygroundCompilationTimeoutException,
+]

--- a/docker/stan-wasm-server/logic/exceptions.py
+++ b/docker/stan-wasm-server/logic/exceptions.py
@@ -1,65 +1,27 @@
-from fastapi import FastAPI
-from fastapi.responses import JSONResponse
-from fastapi import Request
-
-
-class StanPlaygroundException(Exception):
-    """Base exception for the Stan Playground."""
-    code: int
-    def to_message(self):
-        return str(self)
-
-    @classmethod
-    def register_handler(cls, app: FastAPI):
-        @app.exception_handler(cls)
-        async def _(request: Request, exc: cls):
-            return JSONResponse(
-                status_code=cls.code,
-                content={
-                    "message": exc.to_message()
-                }
-            )
-
-class StanPlaygroundAuthenticationException(StanPlaygroundException):
+class StanPlaygroundAuthenticationException(Exception):
     """Raise if authentication failed."""
-    code: int = 401
 
-class StanPlaygroundInvalidJobException(StanPlaygroundException):
+class StanPlaygroundInvalidJobException(Exception):
     """Raise if an invalid job ID is requested."""
-    code: int = 400
-    def to_message(self):
-        return f"Invalid job ID {self}"
+    def __init__(self, job_id):
+        super().__init__(f"Invalid job ID {job_id}")
 
-class StanPlaygroundJobNotFoundException(StanPlaygroundException):
+class StanPlaygroundJobNotFoundException(Exception):
     """Raise if a job ID is valid but the job directory does not exist."""
-    code: int = 404
-    def to_message(self):
-        return f"Job {self} not found."
+    def __init__(self, job_id):
+        super().__init__(f"Job ID {job_id} not found")
 
-class StanPlaygroundAlreadyUploaded(StanPlaygroundException):
+class StanPlaygroundAlreadyUploaded(Exception):
     """Raise if a request cannot be completed due to the current job status."""
-    code: int = 409
 
-class StanPlaygroundInvalidFileException(StanPlaygroundException):
+class StanPlaygroundInvalidFileException(Exception):
     """Raise if a submitted file is not valid (e.g. exceeds size limits)"""
-    code: int = 400
 
-class StanPlaygroundCompilationException(StanPlaygroundException):
+class StanPlaygroundCompilationException(Exception):
     """Raise if compilation failed for non-timeout (including unknown) reasons."""
-    code: int = 422
 
-class StanPlaygroundCompilationTimeoutException(StanPlaygroundException):
+class StanPlaygroundCompilationTimeoutException(Exception):
     """Raise if compilation failed due to timeout specifically."""
-    code: int = 400
-    def to_message(self):
-        return "Model compilation took too long to complete"
+    def __init__(self):
+        super().__init__("Model compilation took too long to complete")
 
-ALL_EXCEPTIONS = [
-    StanPlaygroundAuthenticationException,
-    StanPlaygroundInvalidJobException,
-    StanPlaygroundJobNotFoundException,
-    StanPlaygroundAlreadyUploaded,
-    StanPlaygroundInvalidFileException,
-    StanPlaygroundCompilationException,
-    StanPlaygroundCompilationTimeoutException,
-]

--- a/docker/stan-wasm-server/logic/file_validation/compilation_files.py
+++ b/docker/stan-wasm-server/logic/file_validation/compilation_files.py
@@ -2,12 +2,13 @@ from pathlib import Path
 
 from ..exceptions import StanPlaygroundInvalidFileException
 
+COMPILATION_OUTPUTS = ['main.js', 'main.wasm']
+
 # 10 MB limit for Stan source files
 MAX_STAN_SRC_FILESIZE = 1024 * 1024 * 10
-VALID_STAN_COMPILATION_OUTPUTS_FILENAMES = ['main.js', 'main.wasm']
 
 def download_filename_is_valid(filename: str):
-    return filename in VALID_STAN_COMPILATION_OUTPUTS_FILENAMES
+    return filename in COMPILATION_OUTPUTS
 
 
 def _stan_src_file_is_within_size_limit(data: bytes):

--- a/docker/stan-wasm-server/logic/file_validation/compilation_files.py
+++ b/docker/stan-wasm-server/logic/file_validation/compilation_files.py
@@ -14,6 +14,8 @@ def download_filename_is_valid(filename: str):
 def _stan_src_file_is_within_size_limit(data: bytes):
     return len(data) <= MAX_STAN_SRC_FILESIZE
 
+def compilation_files_exist(model_dir: Path):
+    return all((model_dir / x).exists() for x in COMPILATION_OUTPUTS)
 
 def write_stan_code_file(file_location: Path, data: bytes):
     if not _stan_src_file_is_within_size_limit(data):

--- a/docker/stan-wasm-server/main.py
+++ b/docker/stan-wasm-server/main.py
@@ -9,28 +9,12 @@ from pathlib import Path
 from logic.definitions import CompilationStatus
 from logic.compilation_job_mgmt import (
     create_compilation_job,
-    get_compilation_job_dir,
     get_job_source_file,
-    read_compilation_job_status,
-    write_compilation_job_status,
-    validate_compilation_job_runnable_status,
     upload_stan_code_file,
-    get_compiled_file_path,
-    write_compilation_logfile
 )
-from logic.compilation import make_canonical_model_dir, try_compile_stan_program
+from logic.compilation import COMPILATION_OUTPUTS, make_canonical_model_dir, compile_and_cache
 from logic.authorization import check_authorization
-from logic.exceptions import (
-    StanPlaygroundAuthenticationException,
-    StanPlaygroundJobNotFoundException,
-    StanPlaygroundInvalidJobException,
-    StanPlaygroundBadStatusException,
-    StanPlaygroundInvalidFileException
-)
-
-#  NOTE: While less significant than compilation locks, the risk of race conditions also
-# applies to tracking status using the file system. Consider implementing a (single-threaded)
-# status tracker to track this state globally. (Can also act as a lock server.)
+from logic import exceptions
 
 app = FastAPI()
 
@@ -55,54 +39,18 @@ if not (
 
 
 ##### Custom exception handlers
+for exc in exceptions.ALL_EXCEPTIONS:
+    exc.register_handler(app)
 
-@app.exception_handler(StanPlaygroundAuthenticationException)
-async def authentication_handler(request: Request, exc: StanPlaygroundAuthenticationException):
-    return JSONResponse(
-        status_code=401,
-        content={
-            "message": str(exc)
-        }
-    )
-
-@app.exception_handler(StanPlaygroundInvalidJobException)
-async def invalid_job_handler(request: Request, exc: StanPlaygroundInvalidJobException):
-    return JSONResponse(
-        status_code=400,
-        content={
-            "message": f"Invalid job ID {str(exc)}"
-        }
-    )
-
-
-@app.exception_handler(StanPlaygroundJobNotFoundException)
-async def job_not_found_handler(request: Request, exc: StanPlaygroundJobNotFoundException):
+@app.exception_handler(FileNotFoundError)
+async def file_not_found_handler(request: Request, exc: FileNotFoundError):
     return JSONResponse(
         status_code=404,
         content={
-            "message": f"Job {str(exc)} not found."
+            "message": f"File not found: {exc}"
         }
     )
 
-
-@app.exception_handler(StanPlaygroundBadStatusException)
-async def bad_status_handler(request: Request, exc: StanPlaygroundBadStatusException):
-    return JSONResponse(
-        status_code=409,
-        content={
-            "message": str(exc)
-        }
-    )
-
-
-@app.exception_handler(StanPlaygroundInvalidFileException)
-async def bad_file_handler(request: Request, exc: StanPlaygroundInvalidFileException):
-    return JSONResponse(
-        status_code=400,
-        content={
-            "message": str(exc)
-        }
-    )
 
 ##### Routing
 
@@ -118,12 +66,6 @@ async def initiate_job(authorization: str = Header(None)):
     return {"job_id": job_id, "status": CompilationStatus.INITIATED}
 
 
-@app.get("/job/{job_id}/status")
-async def job_status(job_id: str):
-    status = read_compilation_job_status(job_id)
-    return {"job_id": job_id, "status": status}
-
-
 @app.post("/job/{job_id}/upload/{filename}")
 async def upload_stan_source_file(job_id: str, filename: str, data: bytes = Body(...)):
     # QUERY: Should this endpoint also validate authorization?
@@ -133,19 +75,23 @@ async def upload_stan_source_file(job_id: str, filename: str, data: bytes = Body
 
 @app.get("/job/{job_id}/download/{filename}")
 async def download_file(job_id: str, filename: str):
-    return FileResponse(get_compiled_file_path(job_id, filename))
+    if filename not in COMPILATION_OUTPUTS:
+        raise exceptions.StanPlaygroundInvalidFileException(f"Invalid file name {filename}")
+
+    src_file = get_job_source_file(job_id)
+    model_dir = make_canonical_model_dir(src_file)
+
+    file_path = model_dir / filename
+    if not file_path.is_file():
+        raise FileNotFoundError(str(file_path))
+    return FileResponse(file_path)
 
 
 @app.post("/job/{job_id}/run")
 async def run_job(job_id: str):
-    job_dir = get_compilation_job_dir(job_id)
-    validate_compilation_job_runnable_status(job_id)
     src_file = get_job_source_file(job_id)
     model_dir = make_canonical_model_dir(src_file)
 
-    (status, err_msg) = await try_compile_stan_program(job_dir=job_dir, model_dir=model_dir, tinystan_dir=TINYSTAN_DIR, preserve_on_fail=False)
-    if (err_msg != ''):
-        write_compilation_logfile(job_id, err_msg)
-    write_compilation_job_status(job_id, status)
-    return {"job_id": job_id, "status": status.value}
-    
+    await compile_and_cache(job_id=job_id, model_dir=model_dir, tinystan_dir=TINYSTAN_DIR)
+
+    return {"job_id": job_id, "status": CompilationStatus.COMPLETED}

--- a/gui/src/app/compileStanProgram/compileStanProgram.ts
+++ b/gui/src/app/compileStanProgram/compileStanProgram.ts
@@ -1,4 +1,4 @@
-const compileStanProgram = async (stanWasmServerUrl: string, stanProgram: string, onStatus: (s: string) => void): Promise<{mainJsUrl?: string, jobId?: string}> => {
+const compileStanProgram = async (stanWasmServerUrl: string, stanProgram: string, onStatus: (s: string) => void): Promise<{ mainJsUrl?: string, jobId?: string }> => {
     try {
         onStatus("initiating job");
         const initiateJobUrl = `${stanWasmServerUrl}/job/initiate`
@@ -45,7 +45,12 @@ const compileStanProgram = async (stanWasmServerUrl: string, stanProgram: string
             }
         });
         if (!c.ok) {
-            onStatus(`failed to run job: ${c.statusText}`);
+            let j = await c.json();
+            if (j.message) {
+                onStatus(`failed to run job: ${j.message}`);
+            } else {
+                onStatus(`failed to run job: ${c.statusText}`);
+            }
             return {}
         }
         const respC = await c.json();
@@ -66,11 +71,11 @@ const compileStanProgram = async (stanWasmServerUrl: string, stanProgram: string
 
 
         onStatus("compiled");
-        return {mainJsUrl: downloadMainJsUrl, jobId: job_id}
+        return { mainJsUrl: downloadMainJsUrl, jobId: job_id }
     }
     catch (e) {
         onStatus(`failed to compile: ${e}`);
-        return {mainJsUrl: undefined}
+        return { mainJsUrl: undefined }
     }
 }
 

--- a/gui/src/app/compileStanProgram/compileStanProgram.ts
+++ b/gui/src/app/compileStanProgram/compileStanProgram.ts
@@ -46,11 +46,7 @@ const compileStanProgram = async (stanWasmServerUrl: string, stanProgram: string
         });
         if (!c.ok) {
             let j = await c.json();
-            if (j.message) {
-                onStatus(`failed to run job: ${j.message}`);
-            } else {
-                onStatus(`failed to run job: ${c.statusText}`);
-            }
+            onStatus(`failed to run job: ${j.message ?? c.statusText}`);
             return {}
         }
         const respC = await c.json();

--- a/gui/src/app/compileStanProgram/compileStanProgram.ts
+++ b/gui/src/app/compileStanProgram/compileStanProgram.ts
@@ -46,7 +46,7 @@ const compileStanProgram = async (stanWasmServerUrl: string, stanProgram: string
         });
         if (!c.ok) {
             let j = await c.json();
-            onStatus(`failed to run job: ${j.message ?? c.statusText}`);
+            onStatus(`failed to run job: ${j?.message ?? c.statusText}`);
             return {}
         }
         const respC = await c.json();


### PR DESCRIPTION
This PR makes some simplifications to the build setup that lead to slightly more consistent behavior.

The new flow of information is:

1. A request to build a model comes in
2. We check to see if it has already been built and cached in the $MODEL_HASH folder
   a. If so, we return*
3. Assuming it was not a cache hit, we build the model _in the job folder_. This means a job always has something to do, removing the case before where it would be told that compilation was already running and fail
4. Copy the output to the $MODEL_HASH folder*

The * above indicate places where we need to take or wait on a lock to make sure we aren't viewing incomplete copies on the filesystem, but in general this locking is simpler (and the critical section much smaller) than before.


This allowed us to remove some code that was tracking statuses. I also moved the exception registration into a more data-driven style that doesn't have as many repeated functions in the main.py file.  