### PR TITLE
Backend: use Pydantic Settings object for config

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,6 +31,10 @@ RUN mkdir oneTBB/build && cd oneTBB/build && \
     cmake --build . -j$(nproc) && \
     cmake --install .
 
+# Install Python dependencies
+RUN pip install fastapi[all]
+RUN pip install uvicorn
+
 # Clone the TinyStan repository and checkout a specific commit
 RUN git clone https://github.com/WardBrian/tinystan.git && \
     cd tinystan && \
@@ -45,8 +49,6 @@ RUN cd tinystan && \
     emmake make test_models/bernoulli/bernoulli.js -j$(nproc) && \
     emstrip test_models/bernoulli/bernoulli.wasm
 
-RUN pip install fastapi
-RUN pip install uvicorn
 COPY stan-wasm-server /stan-wasm-server
 WORKDIR /stan-wasm-server
 

--- a/docker/stan-wasm-server/config.py
+++ b/docker/stan-wasm-server/config.py
@@ -1,0 +1,32 @@
+from functools import lru_cache
+from pathlib import Path
+
+from pydantic import (AliasChoices, DirectoryPath, Field, PositiveInt,
+                      SecretStr, field_validator)
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class StanWasmServerSettings(BaseSettings):
+    model_config = SettingsConfigDict(env_prefix="SWS_")
+
+    passcode: SecretStr
+    job_dir: Path = Path("/jobs")
+    built_model_dir: Path = Path("/compiled_models")
+    compilation_timeout: PositiveInt = 60 * 5
+    tinystan: DirectoryPath = Field(
+        validation_alias=AliasChoices("tinystan", "tinystan_dir")
+    )
+
+    @field_validator("tinystan")
+    @classmethod
+    def tinystan_contains_installation(cls, v: Path) -> Path:
+        if not ((v / "Makefile").is_file() and (v / "stan").is_dir()):
+            raise ValueError(
+                f"Tinystan path '{v}' does not appear to contain a working installation."
+            )
+        return v.absolute()
+
+
+@lru_cache
+def get_settings() -> StanWasmServerSettings:
+    return StanWasmServerSettings()

--- a/docker/stan-wasm-server/logic/authorization.py
+++ b/docker/stan-wasm-server/logic/authorization.py
@@ -1,20 +1,13 @@
-import os
+from pydantic import SecretStr
+
 from .exceptions import StanPlaygroundAuthenticationException
 
-SWS_PASSCODE = os.environ.get("SWS_PASSCODE", "")
-if not SWS_PASSCODE:
-    raise ValueError("SWS_PASSCODE environment variable not set")
 
-
-def _passcode_is_valid(passcode: str):
-    return passcode == SWS_PASSCODE
-
-
-def check_authorization(authorization: str):
+def check_authorization(authorization: str, passcode: SecretStr):
     if not authorization:
         raise StanPlaygroundAuthenticationException("Passcode not provided")
     if not authorization.startswith("Bearer "):
         raise StanPlaygroundAuthenticationException("Invalid authorization header")
-    passcode = authorization.split(" ")[1]
-    if not _passcode_is_valid(passcode):
+    user_passcode = authorization.split(" ")[1]
+    if not user_passcode == passcode.get_secret_value():
         raise StanPlaygroundAuthenticationException("Invalid passcode")

--- a/docker/stan-wasm-server/logic/compilation.py
+++ b/docker/stan-wasm-server/logic/compilation.py
@@ -1,15 +1,14 @@
 import asyncio
 from hashlib import sha1
-from shutil import copy2
 from pathlib import Path
+from shutil import copy2
 
+from .compilation_job_mgmt import get_job_source_file
+from .exceptions import (StanPlaygroundCompilationException,
+                         StanPlaygroundCompilationTimeoutException)
+from .file_validation.compilation_files import (COMPILATION_OUTPUTS,
+                                                compilation_files_exist)
 from .locking import compilation_output_lock, wait_until_free
-from .exceptions import StanPlaygroundCompilationException, StanPlaygroundCompilationTimeoutException
-from .compilation_job_mgmt import get_job_source_file, get_compilation_job_dir
-from .file_validation.compilation_files import COMPILATION_OUTPUTS, compilation_files_exist
-
-COMPILED_MODELS_BASE_PATH = Path('/compiled_models')
-COMPILATION_TIMEOUT = 60 * 5
 
 
 def _compute_stan_program_hash(program_file: Path):
@@ -18,15 +17,14 @@ def _compute_stan_program_hash(program_file: Path):
     return sha1(stan_program.encode()).hexdigest()
 
 
-def make_canonical_model_dir(src_file: Path):
+def make_canonical_model_dir(src_file: Path, built_model_dir: Path) -> Path:
     stan_program_hash = _compute_stan_program_hash(src_file)
-    model_dir = COMPILED_MODELS_BASE_PATH / stan_program_hash
+    model_dir = built_model_dir / stan_program_hash
     model_dir.mkdir(exist_ok=True, parents=True)
     return model_dir.absolute()
 
 
-def copy_compiled_files_to_cache(job_id: str, model_dir: Path):
-    job_dir = get_compilation_job_dir(job_id)
+def copy_compiled_files_to_cache(job_dir: Path, model_dir: Path):
     for file in COMPILATION_OUTPUTS:
         source = job_dir / file
         if not source.exists():
@@ -41,15 +39,15 @@ def copy_compiled_files_to_cache(job_id: str, model_dir: Path):
         copy2(job_dir / file, model_dir / file)
 
 
-async def compile_and_cache(*, job_id: str, model_dir: Path, tinystan_dir: Path):
+async def compile_and_cache(*, job_dir: Path, model_dir: Path, tinystan_dir: Path, timeout: int):
     if compilation_files_exist(model_dir):
         # if there's a cache hit, make sure any copying is already complete,
         # then return without compiling
-        wait_until_free(model_dir)
+        await wait_until_free(model_dir)
         return
 
     # otherwise, compile in our job-specific folder
-    await compile_stan_program(job_id=job_id, tinystan_dir=tinystan_dir)
+    await compile_stan_program(job_dir=job_dir, tinystan_dir=tinystan_dir, timeout=timeout)
 
     # then, try to copy into the cache
     with compilation_output_lock(model_dir) as exclusive:
@@ -59,29 +57,30 @@ async def compile_and_cache(*, job_id: str, model_dir: Path, tinystan_dir: Path)
         # we were compiling (and we don't need to copy).
         if exclusive:
             if not compilation_files_exist(model_dir):
-                copy_compiled_files_to_cache(job_id, model_dir)
+                copy_compiled_files_to_cache(job_dir, model_dir)
         # if we failed in getting the lock, it means
         # another thread is currently copying, and we wait for them.
         # We do not need to copy, because their version will be
         # equivalent; we wasted some time, but that's ultimately okay
         else:
-            wait_until_free(model_dir)
+            await wait_until_free(model_dir)
 
 
 
-async def compile_stan_program(*, job_id: str, tinystan_dir: Path, ):
+async def compile_stan_program(*, job_dir: Path, tinystan_dir: Path, timeout: int):
     """
     Compiles the Stan program in the job directory
 
     Args:
         job_dir: Job directory for the incoming job
         tinystan_dir: Location of the tinystan installation (with compilation tools)
+        timeout: Maximum number of seconds to allow compilation to take
     """
     try:
-        job_main = get_job_source_file(job_id)
+        job_main = get_job_source_file(job_dir)
         cmd = f"emmake make {job_main.with_suffix('.js')} && emstrip {job_main.with_suffix('.wasm')}"
         process = await asyncio.create_subprocess_shell(cmd, cwd=tinystan_dir)
-        await asyncio.wait_for(process.wait(), timeout=COMPILATION_TIMEOUT)
+        await asyncio.wait_for(process.wait(), timeout=timeout)
     except (asyncio.TimeoutError, TimeoutError):
         raise StanPlaygroundCompilationTimeoutException()
 

--- a/docker/stan-wasm-server/logic/compilation_job_mgmt.py
+++ b/docker/stan-wasm-server/logic/compilation_job_mgmt.py
@@ -1,22 +1,17 @@
-from uuid import uuid4
-from string import hexdigits
 from pathlib import Path
+from string import hexdigits
+from uuid import uuid4
 
+from .exceptions import (StanPlaygroundAlreadyUploaded,
+                         StanPlaygroundInvalidFileException,
+                         StanPlaygroundInvalidJobException,
+                         StanPlaygroundJobNotFoundException)
 from .file_validation.compilation_files import write_stan_code_file
 
-from .exceptions import (
-    StanPlaygroundAlreadyUploaded,
-    StanPlaygroundJobNotFoundException,
-    StanPlaygroundInvalidJobException,
-    StanPlaygroundInvalidFileException,
-)
 
-# NOTE: Consider an explicit root
-BASE_JOB_DIR = Path("/jobs")
-
-def create_compilation_job():
+def create_compilation_job(base_dir: Path):
     job_id = _create_compilation_job_id()
-    get_compilation_job_dir(job_id, create_if_missing=True)
+    get_compilation_job_dir(job_id, base_dir, create_if_missing=True)
     return job_id
 
 
@@ -28,9 +23,14 @@ def _is_valid_compilation_job_id(job_id: str):
     return len(job_id) == 32 and all(c in hexdigits for c in job_id)
 
 
-def get_compilation_job_dir(job_id: str, *, create_if_missing: bool = False):
+def _validate_compilation_job_id(job_id: str):
+    if not _is_valid_compilation_job_id(job_id):
+        raise StanPlaygroundInvalidJobException(job_id)
+
+
+def get_compilation_job_dir(job_id: str, base_dir: Path, *, create_if_missing: bool = False):
     _validate_compilation_job_id(job_id)
-    job_dir = BASE_JOB_DIR / job_id
+    job_dir = base_dir / job_id
     if create_if_missing:
         job_dir.mkdir(parents=True)
     else:
@@ -39,35 +39,16 @@ def get_compilation_job_dir(job_id: str, *, create_if_missing: bool = False):
     return job_dir
 
 
-def get_job_source_file(job_id: str, for_writing: bool = False):
-    job_dir = get_compilation_job_dir(job_id)
+def get_job_source_file(job_dir: Path, for_writing: bool = False):
     srcfile = job_dir / "main.stan"
 
     if not for_writing and not srcfile.exists():
         raise StanPlaygroundInvalidFileException("Not found")
     elif for_writing and srcfile.exists():
-        raise StanPlaygroundAlreadyUploaded(f"Cannot upload files to job {job_id}, already uploaded!")
+        raise StanPlaygroundAlreadyUploaded(f"Cannot upload files to job {job_dir.stem}, already uploaded!")
     return srcfile
 
 
-def _validate_compilation_job_id(job_id: str):
-    if not _is_valid_compilation_job_id(job_id):
-        raise StanPlaygroundInvalidJobException(job_id)
-
-
-def _get_compilation_logfile_path(job_id: str):
-    job_dir = get_compilation_job_dir(job_id)
-    logfile_name = job_dir / "log.txt"
-    return logfile_name
-
-
-def write_compilation_logfile(job_id: str, msg: str):
-    log = _get_compilation_logfile_path(job_id)
-    with log.open(mode="a") as fp:
-        fp.write(msg)
-
-
-def upload_stan_code_file(job_id: str, filename: str, data: bytes):
-    # filename is currently intentionally unused
-    file = get_job_source_file(job_id, for_writing=True)
+def upload_stan_code_file(job_dir: Path, data: bytes):
+    file = get_job_source_file(job_dir, for_writing=True)
     write_stan_code_file(file, data)

--- a/docker/stan-wasm-server/logic/locking.py
+++ b/docker/stan-wasm-server/logic/locking.py
@@ -1,6 +1,6 @@
-import time
-from pathlib import Path
+import asyncio
 from contextlib import contextmanager
+from pathlib import Path
 from typing import Generator
 
 
@@ -9,10 +9,10 @@ def _get_compilation_lockfile_name(model_dir: Path):
     return p
 
 
-def wait_until_free(model_dir: Path):
+async def wait_until_free(model_dir: Path):
     lockfile = _get_compilation_lockfile_name(model_dir)
     while lockfile.is_file():
-        time.sleep(0.5)
+        await asyncio.sleep(1)
 
 
 @contextmanager


### PR DESCRIPTION
Closes #33.

This adds a `config.py` which stores the global settings for the project. 

A few functions needed to be rethought/changed to take in these settings rather than depend on globals, which is the reason for most of the changes outside `main.py`