### PR TITLE
Backend: add basic logging

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -53,5 +53,6 @@ COPY stan-wasm-server /stan-wasm-server
 WORKDIR /stan-wasm-server
 
 ENV SWS_PASSCODE=1234
+ENV SWS_LOG_LEVEL=debug
 ENV TINYSTAN_DIR=/app/tinystan
 CMD ["bash", "run.sh"]

--- a/backend/stan-wasm-server/src/app/config.py
+++ b/backend/stan-wasm-server/src/app/config.py
@@ -1,3 +1,4 @@
+import logging
 from functools import lru_cache
 from pathlib import Path
 
@@ -22,6 +23,15 @@ class StanWasmServerSettings(BaseSettings):
     tinystan: DirectoryPath = Field(
         validation_alias=AliasChoices("tinystan", "tinystan_dir")
     )
+    log_level: str = "INFO"
+
+    @field_validator("log_level")
+    @classmethod
+    def log_level_is_valid(cls, v: str) -> int:
+        v = v.upper()
+        if v not in ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"):
+            raise ValueError(f"Invalid log level: {v}")
+        return getattr(logging, v)  # type: ignore
 
     @field_validator("tinystan")
     @classmethod

--- a/backend/stan-wasm-server/src/app/logic/definitions.py
+++ b/backend/stan-wasm-server/src/app/logic/definitions.py
@@ -1,9 +1,0 @@
-from enum import Enum
-
-
-# TODO: Change to EnumStr when we upgrade past python 3.10
-class CompilationStatus(Enum):
-    INITIATED = "initiated"
-    RUNNING = "running"
-    COMPLETED = "completed"
-    FAILED = "failed"

--- a/backend/stan-wasm-server/src/app/main.py
+++ b/backend/stan-wasm-server/src/app/main.py
@@ -12,7 +12,6 @@ from logic.compilation_job_mgmt import (
     get_job_source_file,
     upload_stan_code_file,
 )
-from logic.definitions import CompilationStatus
 from logic.exceptions import (
     StanPlaygroundAlreadyUploaded,
     StanPlaygroundAuthenticationException,
@@ -79,7 +78,7 @@ async def initiate_job(
 ) -> DictResponse:
     check_authorization(authorization, settings.passcode)
     job_id = create_compilation_job(base_dir=settings.job_dir)
-    return {"job_id": job_id, "status": CompilationStatus.INITIATED}
+    return {"job_id": job_id}
 
 
 @app.post("/job/{job_id}/upload/{filename}")
@@ -127,4 +126,4 @@ async def run_job(job_id: str, settings: DependsOnSettings) -> DictResponse:
         timeout=settings.compilation_timeout,
     )
 
-    return {"job_id": job_id, "status": CompilationStatus.COMPLETED}
+    return {"success": True}

--- a/gui/src/app/FileEditor/StanFileEditor.tsx
+++ b/gui/src/app/FileEditor/StanFileEditor.tsx
@@ -44,7 +44,7 @@ const StanFileEditor: FunctionComponent<Props> = ({ fileName, fileContent, onSav
             setCompileMessage(msg)
         }
         const stanWasmServerUrl = localStorage.getItem('stanWasmServerUrl') || 'https://trom-stan-wasm-server.magland.org'
-        const { mainJsUrl, jobId } = await compileStanProgram(stanWasmServerUrl, fileContent, onStatus)
+        const { mainJsUrl } = await compileStanProgram(stanWasmServerUrl, fileContent, onStatus)
 
         if (!mainJsUrl) {
             setCompileStatus('failed')
@@ -55,16 +55,14 @@ const StanFileEditor: FunctionComponent<Props> = ({ fileName, fileContent, onSav
         setTheStanFileContentThasHasBeenCompiled(fileContent)
 
         // record in local storage that we compiled this particular stan file
-        if (jobId) {
-            try {
-                const key = getKeyNameForCompiledFile(stanWasmServerUrl, fileContent)
-                const value = JSON.stringify({ jobId, mainJsUrl })
-                localStorage.setItem(key, value)
-            }
-            catch (e: any) {
-                console.error('Problem recording compiled file in local storage')
-                console.error(e)
-            }
+        try {
+            const key = getKeyNameForCompiledFile(stanWasmServerUrl, fileContent)
+            const value = JSON.stringify({ mainJsUrl })
+            localStorage.setItem(key, value)
+        }
+        catch (e: any) {
+            console.error('Problem recording compiled file in local storage')
+            console.error(e)
         }
     }, [fileContent, setCompiledUrl])
 
@@ -144,7 +142,7 @@ const StanFileEditor: FunctionComponent<Props> = ({ fileName, fileContent, onSav
         <Splitter
             width={width}
             height={height}
-            initialPosition={height  - compileResultsHeight}
+            initialPosition={height - compileResultsHeight}
             direction="vertical"
         >
             <TextEditor

--- a/gui/src/app/compileStanProgram/compileStanProgram.ts
+++ b/gui/src/app/compileStanProgram/compileStanProgram.ts
@@ -1,4 +1,4 @@
-const compileStanProgram = async (stanWasmServerUrl: string, stanProgram: string, onStatus: (s: string) => void): Promise<{ mainJsUrl?: string, jobId?: string }> => {
+const compileStanProgram = async (stanWasmServerUrl: string, stanProgram: string, onStatus: (s: string) => void): Promise<{ mainJsUrl?: string }> => {
     try {
         onStatus("initiating job");
         const initiateJobUrl = `${stanWasmServerUrl}/job/initiate`
@@ -49,11 +49,6 @@ const compileStanProgram = async (stanWasmServerUrl: string, stanProgram: string
             onStatus(`failed to run job: ${j?.message ?? c.statusText}`);
             return {}
         }
-        const respC = await c.json();
-        if (respC.status !== 'completed') {
-            onStatus(`job failed: ${JSON.stringify(respC)}`);
-            return {}
-        }
 
         const downloadMainJsUrl = `${stanWasmServerUrl}/job/${job_id}/download/main.js`;
 
@@ -67,11 +62,11 @@ const compileStanProgram = async (stanWasmServerUrl: string, stanProgram: string
 
 
         onStatus("compiled");
-        return { mainJsUrl: downloadMainJsUrl, jobId: job_id }
+        return { mainJsUrl: downloadMainJsUrl }
     }
     catch (e) {
         onStatus(`failed to compile: ${e}`);
-        return { mainJsUrl: undefined }
+        return {}
     }
 }
 


### PR DESCRIPTION
This adds some usages of Python's built-in `logging` module. 

This adds logs for when
- compilation starts
- compilation ends
- we're copying files
- we hit the cache

I set this up to use the same format as `uvicorn`'s pre-existing logs

I also added some debug-level logs for the locking mechanism 