### PR TITLE
Minimal support for loading from URL query parts

### DIFF
--- a/gui/src/app/pages/HomePage/HomePage.tsx
+++ b/gui/src/app/pages/HomePage/HomePage.tsx
@@ -78,6 +78,10 @@ const HomePage: FunctionComponent<Props> = ({ width, height }) => {
             samplingOptsURL: searchParams.get('samplingOptsURL'),
             title: searchParams.get('t')
         }
+
+        // by setting this here we get a nice history entry in the browser
+        document.title = "Stan Playground" + (remoteProject.title ? ` - ${remoteProject.title}` : '');
+
         setProjectParts(remoteProject);
         // clear search params after reading them
         setSearchParams(new URLSearchParams());
@@ -143,6 +147,8 @@ const HomePage: FunctionComponent<Props> = ({ width, height }) => {
 
     useEffect(() => {
         localStorage.setItem('meta.json', metaContent)
+        const title = JSON.parse(metaContent).title;
+        document.title = "Stan Playground" + (title ? ` - ${title}` : '');
     }, [metaContent])
 
     const doNotSaveOnUnload = useRef<boolean>(false)

--- a/gui/src/app/pages/HomePage/HomePage.tsx
+++ b/gui/src/app/pages/HomePage/HomePage.tsx
@@ -75,10 +75,13 @@ const HomePage: FunctionComponent<Props> = ({ width, height }) => {
 
         if (searchParams.size === 0) return;
 
-        const projectJSONURL = searchParams.get('project');
 
         const getProjectParts = async () => {
+            const projectJSONURL = searchParams.get('project');
             if (projectJSONURL) {
+                if (searchParams.has('stanURL') || searchParams.has('dataURL') || searchParams.has('samplingOptsURL') || searchParams.has('t')) {
+                    console.warn('Ignoring individual query components because project URL is set');
+                }
                 const text = await tryFetch(projectJSONURL);
                 if (text) {
                     const projectObj = JSON.parse(text);

--- a/gui/src/app/pages/HomePage/HomePage.tsx
+++ b/gui/src/app/pages/HomePage/HomePage.tsx
@@ -54,14 +54,14 @@ const defaultSamplingOptsContent = JSON.stringify(defaultSamplingOpts)
 const initialMetaContent = localStorage.getItem('meta.json') || defaultMetaContent
 const initialSamplingOptsContent = localStorage.getItem('samplingOpts.json') || defaultSamplingOptsContent
 
-type RemoteProject = {
+type QueryOptions = {
     stanURL: string | null
     dataURL: string | null
     samplingOptsURL: string | null
     title: string | null
 }
 
-const defaultRemoteProject: RemoteProject = {
+const defaultQueries: QueryOptions = {
     stanURL: null,
     dataURL: null,
     samplingOptsURL: null,
@@ -70,11 +70,9 @@ const defaultRemoteProject: RemoteProject = {
 
 const HomePage: FunctionComponent<Props> = ({ width, height }) => {
     const [searchParams, setSearchParams] = useSearchParams();
-    const [projectParts, setProjectParts] = useState(defaultRemoteProject);
+    const [projectParts, setProjectParts] = useState(defaultQueries);
     useEffect(() => {
-
         if (searchParams.size === 0) return;
-
 
         const getProjectParts = async () => {
             const projectJSONURL = searchParams.get('project');
@@ -85,12 +83,11 @@ const HomePage: FunctionComponent<Props> = ({ width, height }) => {
                 const text = await tryFetch(projectJSONURL);
                 if (text) {
                     const projectObj = JSON.parse(text);
-                    return { ...defaultRemoteProject, ...projectObj };
+                    return { ...defaultQueries, ...projectObj };
                 } else {
                     alert('Failed to load project from ' + projectJSONURL);
                     return null;
                 }
-
             } else {
                 return {
                     stanURL: searchParams.get('stanURL'),
@@ -101,11 +98,11 @@ const HomePage: FunctionComponent<Props> = ({ width, height }) => {
             }
         }
 
-        getProjectParts().then((remoteProject) => {
-            if (remoteProject) {
+        getProjectParts().then((parts) => {
+            if (parts) {
                 // by setting this here we get a nice history entry in the browser
-                document.title = "Stan Playground" + (remoteProject.title ? ` - ${remoteProject.title}` : '');
-                setProjectParts(remoteProject);
+                document.title = "Stan Playground" + (parts.title ? ` - ${parts.title}` : '');
+                setProjectParts(parts);
                 // clear search params after reading them
                 setSearchParams(new URLSearchParams());
             }


### PR DESCRIPTION
This is an alternative to #35 for discussion.

There are five possible query parameters at the moment:

- `stanURL` - where to fetch the stan code from
- `dataURL` - ditto but for data JSON
- `samplingOptsURL`  - ditto but for sampler options
- `t` - title
- `project` - a bit special, this one points to a JSON which _contains any/all of the above_

Here's an example (assuming you are running locally):

http://127.0.0.1:3000/?stanURL=https://raw.githubusercontent.com/stan-dev/example-models/master/misc/eight_schools/eight_schools.stan&dataURL=https://raw.githubusercontent.com/stan-dev/example-models/master/misc/eight_schools/eight_schools.data.json&t=Eight%20Schools

Here's the same content but wrapped up in one JSON:
http://127.0.0.1:3000/?project=https://gist.githubusercontent.com/WardBrian/b6ab1f73d9c45ae43b785b1752a9966b/raw/16e17f1c8b85d4a29ceba3475d695c771e28d870/eightschools.json


This also seems like it is a prime candidate for a further refactor into something like a reducer, but for now I thought it was clearer to see what changed if I held off on anything further.


