### PR TITLE
load analysis content from url query parameters

### DIFF
--- a/gui/src/app/useRoute.ts
+++ b/gui/src/app/useRoute.ts
@@ -32,7 +32,7 @@ const useRoute = () => {
         else {
             return {
                 page: 'home',
-                sourceDataUri: p,
+                sourceDataUri: getSourceDataUriFromQuery(query),
                 title: (query.t || '') as string
             }
         }
@@ -41,7 +41,8 @@ const useRoute = () => {
     const setRoute = useCallback((r: Route, replaceHistory?: boolean) => {
         let newQuery = {...query}
         if (r.page === 'home') {
-            newQuery = {p: '/', t: r.title}
+            const q = getQueryFromSourceDataUri(r.sourceDataUri)
+            newQuery = {p: '/', t: r.title, ...q}
         }
         else if (r.page === 'about') {
             newQuery = {p: '/about'}
@@ -99,6 +100,35 @@ const queryToQueryString = (query: { [key: string]: string | string[] }) => {
         }
     }
     return '?' + a.join('&')
+}
+
+const getSourceDataUriFromQuery = (query: { [key: string]: string | string[] }) => {
+    const stan = query['main.stan'] || ''
+    const data = query['data.json'] || ''
+    const samplingOpts = query['sampling_opts.json'] || ''
+    return `main.stan=${stan}&data.json=${data}&sampling_opts.json=${samplingOpts}`
+}
+
+export const getQueryFromSourceDataUri = (sourceDataUri: string): {
+    'main.stan'?: string
+    'data.json'?: string
+    'sampling_opts.json'?: string
+} => {
+    const q: { [key: string]: string } = {}
+    const parts = sourceDataUri.split('&')
+    const names = ['main.stan', 'data.json', 'sampling_opts.json']
+    for (const part of parts) {
+        const [key, value] = part.split('=')
+        if (names.includes(key)) {
+            q[key] = value
+        }
+    }
+    for (const k in q) {
+        if (!q[k]) {
+            delete q[k]
+        }
+    }
+    return q
 }
 
 export default useRoute


### PR DESCRIPTION
This PR builds on #40 and adds functionality for loading analysis content from url query parameters. Still, no mechanism for sharing or saving local edits to browser storage.

https://stan-playground.vercel.app/?p=/&t=test1&main.stan=https://raw.githubusercontent.com/stan-dev/example-models/master/jupyter/covid-inf-rate/stan/hier_sens_spec_offset_mult.stan&data.json=https://gist.githubusercontent.com/magland/d5bc7d37561539dca14256061c829cc9/raw/9caa215726b336720369c524ffe56353efebcb38/data.json

In this is example the data.json does not correspond to the main.stan... it's just an illustration.