### PR TITLE
hide stan syntax error window by default (2)

### DIFF
--- a/gui/src/app/FileEditor/StanCompileResultWindow.tsx
+++ b/gui/src/app/FileEditor/StanCompileResultWindow.tsx
@@ -1,12 +1,14 @@
-import { Done } from "@mui/icons-material";
+import { Close, Done } from "@mui/icons-material";
 import { FunctionComponent, useEffect, useState } from "react";
 import runStanc from "./runStanc";
+import { SmallIconButton } from "@fi-sci/misc";
 
 type Props = {
     width: number
     height: number
     mainStanText: string | undefined
     onValidityChanged?: (valid: boolean) => void
+    onClose?: () => void
 }
 
 type CompiledModel = {
@@ -15,7 +17,7 @@ type CompiledModel = {
     result: string
 }
 
-const StanCompileResultWindow: FunctionComponent<Props> = ({width, height, mainStanText, onValidityChanged}) => {
+const StanCompileResultWindow: FunctionComponent<Props> = ({width, height, mainStanText, onValidityChanged, onClose}) => {
     const [model, setModel] = useState<CompiledModel | undefined>(undefined)
     useEffect(() => {
         setModel(undefined)
@@ -35,26 +37,37 @@ const StanCompileResultWindow: FunctionComponent<Props> = ({width, height, mainS
     }, [model, onValidityChanged])
 
     if (!model) return <div />
+    let content: any
     if ((model.errors) && (model.errors.length > 0)) {
-        return (
-            <div style={{width, height, color: 'red', padding: 0, overflow: 'auto'}}>
+        content = (
+            <div style={{color: 'red'}}>
                 <h3>Errors</h3>
                 {model.errors.map((error, i) => <div key={i} style={{font: 'courier', fontSize: 13}}><pre>{error}</pre></div>)}
             </div>
         )
     }
-    if ((model.warnings) && (model.warnings.length > 0)) {
-        return (
-            <div style={{width, height, color: 'blue', padding: 0, overflow: 'auto'}}>
+    else if ((model.warnings) && (model.warnings.length > 0)) {
+        content = (
+            <div style={{color: 'blue'}}>
                 <h3>Warnings</h3>
                 {model.warnings.map((warning, i) => <div key={i} style={{font: 'courier', fontSize: 13}}><pre>{warning}</pre></div>)}
             </div>
         )
     }
-    if (model.result === mainStanText) {
-        return (<div style={{color: 'green'}}><Done /> canonical format</div>)
+    else if (model.result === mainStanText) {
+        content = (<div style={{color: 'green'}}><Done /> canonical format</div>)
     }
-    return (<div style={{color: 'green'}}><Done /></div>)
+    else {
+        content = (<div style={{color: 'green'}}><Done /></div>)
+    }
+    return (
+        <div style={{width, height, overflow: 'auto'}}>
+            <div>
+                <SmallIconButton icon={<Close />} onClick={onClose} />
+            </div>
+            {content}
+        </div>
+    )
 }
 
 export default StanCompileResultWindow

--- a/gui/src/app/FileEditor/TextEditor.tsx
+++ b/gui/src/app/FileEditor/TextEditor.tsx
@@ -186,7 +186,7 @@ const ToolbarItemComponent: FunctionComponent<{item: ToolbarItem}> = ({item}) =>
         const {onClick, color, label, tooltip, icon} = item
         if (icon) {
             return (
-                <span>
+                <span style={{color}}>
                 <SmallIconButton
                     onClick={onClick}
                     icon={icon}


### PR DESCRIPTION
(Reimplements #44 to be based on main branch)

Changes
* The syntax error window attached to the Stan file editor is hidden by default
* If there is a syntax error, an icon/button appears in the toolbar
* If user clicks on the icon, the syntax window opens, and stays open while the user types
* The syntax window contains a close button
* If the stan file editor has no text, then there is a different window that opens below instructing the user to open an example to the left.

I created this on top of #40, the stripped down version that abstracts the data model, hoping that can be a base point until we decide how to proceed on that front.

Before button click:
![image](https://github.com/flatironinstitute/stan-playground/assets/3679296/7e4d9e29-273b-4ebb-9049-09fdc16b5f9d)

After button click:
![image](https://github.com/flatironinstitute/stan-playground/assets/3679296/09dc009b-4698-442d-9f2a-19b564de6d2e)