### PR TITLE
[NO MERGE] prototypes for data.py and data.r

### DIFF
--- a/gui/package.json
+++ b/gui/package.json
@@ -23,6 +23,7 @@
     "jszip": "^3.10.1",
     "monaco-editor": "^0.48.0",
     "plotly.js": "^2.33.0",
+    "pyodide": "^0.26.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-markdown": "^8",
@@ -34,7 +35,8 @@
     "rehype-raw": "^6.1.1",
     "remark-gfm": "^4.0.0",
     "remark-math": "^6.0.0",
-    "tinystan": "^0.0.2"
+    "tinystan": "^0.0.2",
+    "webr": "^0.3.3"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.1.0",

--- a/gui/src/app/FileEditor/TextEditor.tsx
+++ b/gui/src/app/FileEditor/TextEditor.tsx
@@ -140,7 +140,7 @@ const TextEditor: FunctionComponent<Props> = ({defaultText, text, onSaveText, ed
     return (
         <div style={{position: 'absolute', width, height, overflow: 'hidden'}} onKeyDown={handleKeyDown}>
             <NotSelectable>
-                <div style={{position: 'absolute', paddingLeft: 20, paddingTop: 3, width: width - 50, height: toolbarHeight, backgroundColor: 'lightgray', overflow: 'hidden'}}>
+                <div style={{position: 'absolute', paddingLeft: 20, paddingTop: 3, width: width - 20, height: toolbarHeight, backgroundColor: 'lightgray', overflow: 'hidden'}}>
                     {label}
                     &nbsp;&nbsp;&nbsp;
                     {!readOnly && (

--- a/gui/src/app/MainWindow.tsx
+++ b/gui/src/app/MainWindow.tsx
@@ -3,6 +3,7 @@ import { FunctionComponent } from "react";
 import StatusBar, { statusBarHeight } from "./StatusBar";
 import HomePage from "./pages/HomePage/HomePage";
 import useRoute from "./useRoute";
+import PrototypesWindow from "./Prototypes/PrototypesWindow";
 
 type Props = {
     // none
@@ -18,8 +19,11 @@ const MainWindow: FunctionComponent<Props> = () => {
                 {
                     route.page === 'home' ? (
                         <HomePage width={width} height={H} />
-                    ) : route.page === 'about' ? (
-                        <HomePage width={width} height={H} />
+                    ) : route.page === 'prototypes' ? (
+                        <PrototypesWindow
+                            width={width}
+                            height={H}
+                        />
                     ) : (
                         <div>404</div>
                     )

--- a/gui/src/app/Prototypes/AnalysisPyPrototype/AnalysisPyFileEditor.tsx
+++ b/gui/src/app/Prototypes/AnalysisPyPrototype/AnalysisPyFileEditor.tsx
@@ -1,0 +1,159 @@
+import { FunctionComponent, useCallback, useMemo, useState } from "react";
+import { PlayArrow } from "@mui/icons-material";
+import { PyodideInterface, loadPyodide } from "pyodide";
+import TextEditor, { ToolbarItem } from "../../FileEditor/TextEditor";
+
+type Props = {
+    fileName: string
+    fileContent: string
+    onSaveContent: (text: string) => void
+    editedFileContent: string
+    setEditedFileContent: (text: string) => void
+    readOnly: boolean
+    width: number
+    height: number
+    outputDiv?: HTMLDivElement | null
+}
+
+const AnalysisPyFileEditor: FunctionComponent<Props> = ({fileName, fileContent, onSaveContent, editedFileContent, setEditedFileContent, readOnly, width, height, outputDiv}) => {
+    const [status, setStatus] = useState<'idle' | 'loading' | 'running' | 'completed' | 'failed'>('idle')
+
+    const loadPyodideInstance = useMemo(() => {
+        let pyodide: PyodideInterface | null = null
+        const loadPyodideInstance = async () => {
+            if (pyodide === null) {
+                const p = await loadPyodide({
+                    indexURL: "https://cdn.jsdelivr.net/pyodide/v0.26.1/full",
+                    stdout: (x: string) => {
+                        const color = 'blue'
+                        const pre = document.createElement('pre')
+                        pre.style.color = color
+                        pre.appendChild(document.createTextNode(x))
+                        outputDiv?.appendChild(pre)
+                    },
+                    stderr: (x: string) => {
+                        const color = 'red'
+                        const pre = document.createElement('pre')
+                        pre.style.color = color
+                        pre.appendChild(document.createTextNode(x))
+                        outputDiv?.appendChild(pre)
+                    }
+                })
+                pyodide = p
+                await pyodide.loadPackage(['numpy', 'matplotlib'])
+                return pyodide
+            } else {
+                return pyodide
+            }
+        }
+        return loadPyodideInstance
+    }, [outputDiv])
+
+    const handleRun = useCallback(async () => {
+        if (status === 'running') {
+            return
+        }
+        if (editedFileContent !== fileContent) {
+            throw new Error('Cannot run edited code')
+        }
+        const oldPyodideMplTarget = (document as any).pyodideMplTarget;
+        (document as any).pyodideMplTarget = outputDiv;
+        // clear the output div
+        if (outputDiv) {
+            outputDiv.innerHTML = ''
+        }
+        setStatus('loading')
+        await new Promise(resolve => setTimeout(resolve, 100))
+        try {
+            const pyodide = await loadPyodideInstance()
+            setStatus('running')
+            await new Promise(resolve => setTimeout(resolve, 100))
+
+            // here's where we can pass in globals
+            const globals = pyodide.toPy({ _sp_example_global: 5 });
+            let script = fileContent
+            pyodide.runPython(script, {globals})
+            setStatus('completed')
+        }
+        catch (e: any) {
+            console.error(e)
+            const pre = document.createElement('pre')
+            pre.style.color = 'red'
+            pre.appendChild(document.createTextNode(e.toString()))
+            outputDiv?.appendChild(pre)
+            setStatus('failed')
+        }
+        finally {
+            (document as any).pyodideMplTarget = oldPyodideMplTarget;
+        }
+    }, [editedFileContent, fileContent, status, loadPyodideInstance, outputDiv])
+    const toolbarItems: ToolbarItem[] = useMemo(() => {
+        const ret: ToolbarItem[] = []
+        const runnable = (fileContent === editedFileContent) && outputDiv
+        if (runnable) {
+            ret.push({
+                type: 'button',
+                tooltip: 'Run script',
+                label: 'Run',
+                icon: <PlayArrow />,
+                onClick: handleRun,
+                color: 'black',
+            })
+        }
+        if (!outputDiv) {
+            ret.push({
+                type: 'text',
+                label: 'No output window',
+                color: 'red'
+            })
+        }
+        let label: string
+        let color: string
+        if (status === 'loading') {
+            label = 'Loading pyodide...'
+            color = 'blue'
+        }
+        else if (status === 'running') {
+            label = 'Running...'
+            color = 'blue'
+        }
+        else if (status === 'completed') {
+            label = 'Completed'
+            color = 'green'
+        }
+        else if (status === 'failed') {
+            label = 'Failed'
+            color = 'red'
+        }
+        else {
+            label = ''
+            color = 'black'
+        }
+
+        if (label) {
+            ret.push({
+                type: 'text',
+                label,
+                color
+            })
+        }
+        return ret
+    }, [fileContent, editedFileContent, handleRun, status])
+
+    return (
+        <TextEditor
+            width={width}
+            height={height}
+            language="python"
+            label={fileName}
+            text={fileContent}
+            onSaveText={onSaveContent}
+            editedText={editedFileContent}
+            onSetEditedText={setEditedFileContent}
+            readOnly={readOnly}
+            toolbarItems={toolbarItems}
+        />
+    )
+}
+
+export default AnalysisPyFileEditor

--- a/gui/src/app/Prototypes/AnalysisPyPrototype/AnalysisPyPrototype.tsx
+++ b/gui/src/app/Prototypes/AnalysisPyPrototype/AnalysisPyPrototype.tsx
@@ -1,0 +1,93 @@
+import { Splitter } from "@fi-sci/splitter"
+import { FunctionComponent, useEffect, useState } from "react"
+import AnalysisPyFileEditor from "./AnalysisPyFileEditor"
+
+type AnalysisPyPrototypeProps = {
+    width: number
+    height: number
+}
+
+const exampleScript = `import sys
+import numpy as np
+import matplotlib.pyplot as plt
+
+x = np.linspace(0, 2 * np.pi, 100)
+y = np.sin(x)
+
+print('Plotting a sine wave')
+plt.figure()
+plt.plot(x, y, label='Sine Wave')
+plt.title('Sine Wave Example')
+plt.xlabel('Angle (radians)')
+plt.ylabel('Amplitude')
+plt.legend()
+plt.show()
+
+print("This is a test error message", file=sys.stderr)
+
+print('Plotting a cosine wave')
+y2 = np.cos(x)
+plt.figure()
+plt.plot(x, y2, 'r--', label='Cosine Wave')
+plt.title('Cosine Wave Example')
+plt.xlabel('Angle (radians)')
+plt.ylabel('Amplitude')
+plt.legend()
+plt.show()
+
+# Raise an exception intentionally
+raise Exception('test exception')
+`
+
+const AnalysisPyPrototype: FunctionComponent<AnalysisPyPrototypeProps> = ({width, height}) => {
+    const [script, setScript] = useState<string>('')
+    const [editedScript, setEditedScript] = useState<string>('')
+
+    useEffect(() => {
+        setScript(exampleScript)
+        setEditedScript(exampleScript)
+    }, [])
+
+    const [outputDiv, setOutputDiv] = useState<HTMLDivElement | null>(null)
+
+    return (
+        <Splitter
+            width={width}
+            height={height}
+            initialPosition={height / 2}
+            direction="vertical"
+        >
+            <AnalysisPyFileEditor
+                width={0}
+                height={0}
+                fileName="analysis.py"
+                fileContent={script}
+                onSaveContent={setScript}
+                editedFileContent={editedScript}
+                setEditedFileContent={setEditedScript}
+                readOnly={false}
+                outputDiv={outputDiv}
+            />
+            <AnalysisPyOutputWindow
+                width={0}
+                height={0}
+                onOutputDiv={setOutputDiv}
+            />
+        </Splitter>
+    )
+}
+
+type AnalysisPyOutputWindowProps = {
+    width: number
+    height: number
+    onOutputDiv: (div: HTMLDivElement) => void
+}
+
+const AnalysisPyOutputWindow: FunctionComponent<AnalysisPyOutputWindowProps> = ({width, height, onOutputDiv}) => {
+    return (
+        <div style={{width, height, overflow: 'auto'}} ref={onOutputDiv}>
+        </div>
+    )
+}
+
+export default AnalysisPyPrototype

--- a/gui/src/app/Prototypes/DataPyPrototype/DataPyFileEditor.tsx
+++ b/gui/src/app/Prototypes/DataPyPrototype/DataPyFileEditor.tsx
@@ -1,0 +1,184 @@
+import { FunctionComponent, useCallback, useMemo, useState } from "react";
+import { PlayArrow } from "@mui/icons-material";
+import { PyodideInterface, loadPyodide } from "pyodide";
+import TextEditor, { ToolbarItem } from "../../FileEditor/TextEditor";
+
+type Props = {
+    fileName: string
+    fileContent: string
+    onSaveContent: (text: string) => void
+    editedFileContent: string
+    setEditedFileContent: (text: string) => void
+    readOnly: boolean
+    setData?: (data: any) => void
+    width: number
+    height: number
+}
+
+let pyodide: PyodideInterface | null = null
+const loadPyodideInstance = async () => {
+    if (pyodide === null) {
+        const p = await loadPyodide({
+            indexURL: "https://cdn.jsdelivr.net/pyodide/v0.26.1/full",
+            stdout: (x: string) => console.log(x),
+            stderr: (x: string) => console.error(x)
+        })
+        pyodide = p
+        await pyodide.loadPackage(['numpy'])
+        return pyodide
+    } else {
+        return pyodide
+    }
+}
+
+const DataPyFileEditor: FunctionComponent<Props> = ({fileName, fileContent, onSaveContent, editedFileContent, setEditedFileContent, setData, readOnly, width, height}) => {
+    const [status, setStatus] = useState<'idle' | 'loading' | 'running' | 'completed' | 'failed'>('idle')
+    const handleRun = useCallback(async () => {
+        if (status === 'running') {
+            return
+        }
+        if (editedFileContent !== fileContent) {
+            throw new Error('Cannot run edited code')
+        }
+        setStatus('loading')
+        await new Promise(resolve => setTimeout(resolve, 100))
+        try {
+            const pyodide = await loadPyodideInstance()
+            setStatus('running')
+            await new Promise(resolve => setTimeout(resolve, 100))
+
+            // here's where we can pass in globals
+            const globals = pyodide.toPy({ _sp_example_global: 5 });
+            let script = fileContent
+
+            // We serialize the data object to json string in the python script
+            script += '\n'
+            script += 'import numpy as np\n'
+            script += 'def _sp_serialize(x):\n'
+            script += '    if isinstance(x, dict):\n'
+            script += '        ret = {}\n'
+            script += '        for key in x:\n'
+            script += '            ret[key] = _sp_serialize(x[key])\n'
+            script += '        return ret\n'
+            script += '    elif isinstance(x, list):\n'
+            script += '        ret = []\n'
+            script += '        for val in x:\n'
+            script += '            ret.append(_sp_serialize(val))\n'
+            script += '        return ret\n'
+            script += '    elif isinstance(x, tuple):\n'
+            script += '        ret = []\n'
+            script += '        for val in x:\n'
+            script += '            ret.append(_sp_serialize(val))\n'
+            script += '        return ret\n'
+            script += '    elif isinstance(x, np.ndarray):\n'
+            script += '        return _sp_serialize(x.tolist())\n'
+            script += '    else:\n'
+            script += '        return x\n'
+            script += 'import json\n'
+            script += 'data = json.dumps(_sp_serialize(data))\n'
+            pyodide.runPython(script, {globals})
+
+            if (setData) {
+                // get the data object from the python script
+                const data = JSON.parse(globals.get('data'))
+                setData(data)
+            }
+            setStatus('completed')
+        }
+        catch (e) {
+            console.error(e)
+            setStatus('failed')
+        }
+    }, [editedFileContent, fileContent, status, setData])
+    const toolbarItems: ToolbarItem[] = useMemo(() => {
+        const ret: ToolbarItem[] = []
+        const runnable = fileContent === editedFileContent
+        if (runnable) {
+            ret.push({
+                type: 'button',
+                tooltip: 'Run code to generate data',
+                label: 'Run',
+                icon: <PlayArrow />,
+                onClick: handleRun,
+                color: 'black',
+            })
+        }
+        let label: string
+        let color: string
+        if (status === 'loading') {
+            label = 'Loading pyodide...'
+            color = 'blue'
+        }
+        else if (status === 'running') {
+            label = 'Running...'
+            color = 'blue'
+        }
+        else if (status === 'completed') {
+            label = 'Completed'
+            color = 'green'
+        }
+        else if (status === 'failed') {
+            label = 'Failed'
+            color = 'red'
+        }
+        else {
+            label = ''
+            color = 'black'
+        }
+
+        if (label) {
+            ret.push({
+                type: 'text',
+                label,
+                color
+            })
+        }
+        return ret
+    }, [fileContent, editedFileContent, handleRun, status])
+
+    return (
+        <TextEditor
+            width={width}
+            height={height}
+            language="python"
+            label={fileName}
+            text={fileContent}
+            onSaveText={onSaveContent}
+            editedText={editedFileContent}
+            onSetEditedText={setEditedFileContent}
+            readOnly={readOnly}
+            toolbarItems={toolbarItems}
+        />
+    )
+}
+
+const resultToData = (result: any): any => {
+    if (result === null || result === undefined) {
+        return result
+    }
+    if (typeof result !== 'object') {
+        return result
+    }
+    if (result instanceof Map) {
+        const ret: {[key: string]: any} = {}
+        for (const k of result.keys()) {
+            ret[k] = resultToData(result.get(k))
+        }
+        return ret
+    }
+    else if (result instanceof Int16Array || result instanceof Int32Array || result instanceof Int8Array || result instanceof Uint16Array || result instanceof Uint32Array || result instanceof Uint8Array || result instanceof Uint8ClampedArray || result instanceof Float32Array || result instanceof Float64Array) {
+        return Array.from(result)
+    }
+    else if (result instanceof Array) {
+        return result.map(resultToData)
+    }
+    else {
+        const ret: {[key: string]: any} = {}
+        for (const k of Object.keys(result)) {
+            ret[k] = resultToData(result[k])
+        }
+        return ret
+    }
+}
+
+export default DataPyFileEditor

--- a/gui/src/app/Prototypes/DataPyPrototype/DataPyPrototype.tsx
+++ b/gui/src/app/Prototypes/DataPyPrototype/DataPyPrototype.tsx
@@ -1,0 +1,87 @@
+import { Splitter } from "@fi-sci/splitter"
+import { FunctionComponent, useEffect, useMemo, useState } from "react"
+import DataPyFileEditor from "./DataPyFileEditor"
+import TextEditor from "../../FileEditor/TextEditor"
+
+type DataPyPrototypeProps = {
+    width: number
+    height: number
+}
+
+const exampleScript = `import numpy as np
+
+n = 5
+x = np.arange(n)
+y = np.arange(n) ** 2 + np.random.random(n)
+z = [1, 2, 'c']
+
+data = {
+    'x': x,
+    'y': y,
+    'z': z
+}
+`
+
+const DataPyPrototype: FunctionComponent<DataPyPrototypeProps> = ({width, height}) => {
+    const [script, setScript] = useState<string>('')
+    const [editedScript, setEditedScript] = useState<string>('')
+    const [data, setData] = useState<any>(undefined)
+
+    useEffect(() => {
+        setScript(exampleScript)
+        setEditedScript(exampleScript)
+    }, [])
+
+    return (
+        <Splitter
+            width={width}
+            height={height}
+            initialPosition={height / 2}
+            direction="vertical"
+        >
+            <DataPyFileEditor
+                width={0}
+                height={0}
+                fileName="data.py"
+                fileContent={script}
+                onSaveContent={setScript}
+                editedFileContent={editedScript}
+                setEditedFileContent={setEditedScript}
+                readOnly={false}
+                setData={setData}
+            />
+            <DataPyOutputWindow
+                width={0}
+                height={0}
+                data={data}
+            />
+        </Splitter>
+    )
+}
+
+type DataPyOutputWindowProps = {
+    width: number
+    height: number
+    data: any
+}
+
+const DataPyOutputWindow: FunctionComponent<DataPyOutputWindowProps> = ({width, height, data}) => {
+    const text = useMemo(() => data ? JSON.stringify(data, null, 2) : '', [data])
+    return (
+        <div style={{width, height, overflow: 'hidden'}}>
+            <TextEditor
+                width={width}
+                height={height}
+                language="json"
+                label="Data"
+                text={text}
+                editedText={text}
+                onSaveText={() => {}} // do nothing
+                onSetEditedText={() => {}}
+                readOnly={true}
+            />
+        </div>
+    )
+}
+
+export default DataPyPrototype

--- a/gui/src/app/Prototypes/DataRPrototype/DataRFileEditor.tsx
+++ b/gui/src/app/Prototypes/DataRPrototype/DataRFileEditor.tsx
@@ -1,0 +1,124 @@
+import { FunctionComponent, useCallback, useMemo, useState } from "react";
+import TextEditor, { ToolbarItem } from "../../FileEditor/TextEditor";
+import { PlayArrow } from "@mui/icons-material";
+import { WebR } from 'webr';
+
+
+type Props = {
+    fileName: string
+    fileContent: string
+    onSaveContent: (text: string) => void
+    editedFileContent: string
+    setEditedFileContent: (text: string) => void
+    readOnly: boolean
+    setData?: (data: any) => void
+    width: number
+    height: number
+}
+
+let webR: WebR | null = null
+const loadWebRInstance = async () => {
+    if (webR === null) {
+        const w = new WebR()
+        await w.init()
+        w.installPackages(['jsonlite'])
+        webR = w
+        return webR
+    } else {
+        return webR
+    }
+}
+
+const DataRFileEditor: FunctionComponent<Props> = ({fileName, fileContent, onSaveContent, editedFileContent, setEditedFileContent, setData, readOnly, width, height}) => {
+    const [status, setStatus] = useState<'idle' | 'loading' | 'running' | 'completed' | 'failed'>('idle')
+    const handleRun = useCallback(async () => {
+        if (status === 'running') {
+            return
+        }
+        if (editedFileContent !== fileContent) {
+            throw new Error('Cannot run edited code')
+        }
+        setStatus('loading')
+        await new Promise(resolve => setTimeout(resolve, 100))
+        try {
+            const webR = await loadWebRInstance()
+            setStatus('running')
+            await new Promise(resolve => setTimeout(resolve, 100))
+            const rCode = fileContent + '\n\n' + `
+# Convert the list to JSON format
+json_data <- jsonlite::toJSON(data, pretty = TRUE, auto_unbox = TRUE)
+json_data
+            `
+            const result = await webR.evalRString(rCode);
+            if (setData) {
+                setData(JSON.parse(result))
+            }
+            setStatus('completed')
+        }
+        catch (e) {
+            console.error(e)
+            setStatus('failed')
+        }
+    }, [editedFileContent, fileContent, status, setData])
+    const toolbarItems: ToolbarItem[] = useMemo(() => {
+        const ret: ToolbarItem[] = []
+        const runnable = fileContent === editedFileContent
+        if (runnable) {
+            ret.push({
+                type: 'button',
+                tooltip: 'Run code to generate data',
+                label: 'Run',
+                icon: <PlayArrow />,
+                onClick: handleRun,
+                color: 'black',
+            })
+        }
+        let label: string
+        let color: string
+        if (status === 'loading') {
+            label = 'Loading webr...'
+            color = 'blue'
+        }
+        else if (status === 'running') {
+            label = 'Running...'
+            color = 'blue'
+        }
+        else if (status === 'completed') {
+            label = 'Completed'
+            color = 'green'
+        }
+        else if (status === 'failed') {
+            label = 'Failed'
+            color = 'red'
+        }
+        else {
+            label = ''
+            color = 'black'
+        }
+        if (label) {
+            ret.push({
+                type: 'text',
+                label,
+                color
+            })
+        }
+        return ret
+    }, [fileContent, editedFileContent, handleRun, status])
+
+    return (
+        <TextEditor
+            width={width}
+            height={height}
+            language="r"
+            label={fileName}
+            text={fileContent}
+            onSaveText={onSaveContent}
+            editedText={editedFileContent}
+            onSetEditedText={setEditedFileContent}
+            readOnly={readOnly}
+            toolbarItems={toolbarItems}
+        />
+    )
+}
+
+export default DataRFileEditor

--- a/gui/src/app/Prototypes/DataRPrototype/DataRPrototype.tsx
+++ b/gui/src/app/Prototypes/DataRPrototype/DataRPrototype.tsx
@@ -1,0 +1,87 @@
+import { Splitter } from "@fi-sci/splitter"
+import { FunctionComponent, useEffect, useMemo, useState } from "react"
+import TextEditor from "../../FileEditor/TextEditor"
+import DataRFileEditor from "./DataRFileEditor"
+
+type DataRPrototypeProps = {
+    width: number
+    height: number
+}
+
+const exampleScript = `import numpy as np
+
+n = 5
+x = np.arange(n)
+y = np.arange(n) ** 2 + np.random.random(n)
+z = [1, 2, 'c']
+
+data = {
+    'x': x,
+    'y': y,
+    'z': z
+}
+`
+
+const DataRPrototype: FunctionComponent<DataRPrototypeProps> = ({width, height}) => {
+    const [script, setScript] = useState<string>('')
+    const [editedScript, setEditedScript] = useState<string>('')
+    const [data, setData] = useState<any>(undefined)
+
+    useEffect(() => {
+        setScript(exampleScript)
+        setEditedScript(exampleScript)
+    }, [])
+
+    return (
+        <Splitter
+            width={width}
+            height={height}
+            initialPosition={height / 2}
+            direction="vertical"
+        >
+            <DataRFileEditor
+                width={0}
+                height={0}
+                fileName="data.r"
+                fileContent={script}
+                onSaveContent={setScript}
+                editedFileContent={editedScript}
+                setEditedFileContent={setEditedScript}
+                readOnly={false}
+                setData={setData}
+            />
+            <DataROutputWindow
+                width={0}
+                height={0}
+                data={data}
+            />
+        </Splitter>
+    )
+}
+
+type DataROutputWindowProps = {
+    width: number
+    height: number
+    data: any
+}
+
+const DataROutputWindow: FunctionComponent<DataROutputWindowProps> = ({width, height, data}) => {
+    const text = useMemo(() => data ? JSON.stringify(data, null, 2) : '', [data])
+    return (
+        <div style={{width, height, overflow: 'hidden'}}>
+            <TextEditor
+                width={width}
+                height={height}
+                language="json"
+                label="Data"
+                text={text}
+                editedText={text}
+                onSaveText={() => {}} // do nothing
+                onSetEditedText={() => {}}
+                readOnly={true}
+            />
+        </div>
+    )
+}
+
+export default DataRPrototype

--- a/gui/src/app/Prototypes/PrototypesWindow.tsx
+++ b/gui/src/app/Prototypes/PrototypesWindow.tsx
@@ -1,0 +1,89 @@
+import { FunctionComponent, useState } from "react"
+import DataPyPrototype from "./DataPyPrototype/DataPyPrototype"
+import DataRFileEditor from "./DataRPrototype/DataRFileEditor"
+import DataRPrototype from "./DataRPrototype/DataRPrototype"
+
+type TestDataPyWindowProps = {
+    width: number
+    height: number
+}
+
+type ExampleChoice = 'data.py' | 'data.r' | 'analysis.py'
+
+const PrototypesWindow: FunctionComponent<TestDataPyWindowProps> = ({width, height}) => {
+    const leftPanelWidth = 300
+
+    const [exampleChoice, setExampleChoice] = useState<ExampleChoice>('data.py')
+
+    return (
+        <div style={{position: 'absolute', width, height, overflow: 'hidden', background: 'white'}}>
+            <div style={{position: 'absolute', top: 0, left: 0, width: leftPanelWidth, height, overflowY: 'auto'}}>
+                <div style={{padding: 20}}>
+                    <p>
+                        Please make a selection
+                    </p>
+                    <div>
+                        <input type="radio" id="data.py" name="example" value="data.py" checked={exampleChoice === 'data.py'} onChange={() => setExampleChoice('data.py')} />
+                        <label htmlFor="data.py">data.py</label>
+                    </div>
+                    <div>
+                        <input type="radio" id="data.r" name="example" value="data.r" checked={exampleChoice === 'data.r'} onChange={() => setExampleChoice('data.r')} />
+                        <label htmlFor="data.r">data.r</label>
+                    </div>
+                    <div>
+                        <input type="radio" id="analysis.py" name="example" value="analysis.py" checked={exampleChoice === 'analysis.py'} onChange={() => setExampleChoice('analysis.py')} />
+                        <label htmlFor="analysis.py">analysis.py</label>
+                    </div>
+                    {
+                        exampleChoice === 'data.py' ? (
+                            <div>
+                                <p>
+                                    This is an example of how data generation via Python script might work. It uses Pyodide in the browser.
+                                </p>
+                                <p>
+                                    The value of the global variable <code>data</code> is used to pass data from the Python script to the output window.
+                                </p>
+                            </div>
+                        ) : exampleChoice === 'data.r' ? (
+                            <div>
+                                <p>
+                                    This is an example of how data generation via R script might work. It uses webr in the browser.
+                                </p>
+                                <p>
+                                    The value of the global variable <code>data</code> is used to pass data from the R script to the output window.
+                                </p>
+                            </div>
+                        ) : exampleChoice === 'analysis.py' ? (
+                            <div>
+                                <p>
+                                    Not yet implemented.
+                                </p>
+                            </div>
+                        ) : <div />
+                    }
+                </div>
+            </div>
+            <div style={{position: 'absolute', top: 0, left: leftPanelWidth, width: width - leftPanelWidth, height, overflowY: 'hidden'}}>
+                {
+                    exampleChoice === 'data.py' ? (
+                        <DataPyPrototype
+                            width={width - leftPanelWidth}
+                            height={height}
+                        />
+                    ) : exampleChoice === 'data.r' ? (
+                        <DataRPrototype
+                            width={width - leftPanelWidth}
+                            height={height}
+                        />
+                    ) : exampleChoice === 'analysis.py' ? (
+                        <div>
+                            Not yet implemented
+                        </div>
+                    ) : <div />
+                }
+            </div>
+        </div>
+    )
+}
+
+export default PrototypesWindow

--- a/gui/src/app/Prototypes/PrototypesWindow.tsx
+++ b/gui/src/app/Prototypes/PrototypesWindow.tsx
@@ -1,19 +1,26 @@
-import { FunctionComponent, useState } from "react"
+import { FunctionComponent, useCallback, useState } from "react"
+import AnalysisPyPrototype from "./AnalysisPyPrototype/AnalysisPyPrototype"
 import DataPyPrototype from "./DataPyPrototype/DataPyPrototype"
-import DataRFileEditor from "./DataRPrototype/DataRFileEditor"
 import DataRPrototype from "./DataRPrototype/DataRPrototype"
+import useRoute from "../useRoute"
 
 type TestDataPyWindowProps = {
     width: number
     height: number
 }
 
-type ExampleChoice = 'data.py' | 'data.r' | 'analysis.py'
-
 const PrototypesWindow: FunctionComponent<TestDataPyWindowProps> = ({width, height}) => {
     const leftPanelWidth = 300
 
-    const [exampleChoice, setExampleChoice] = useState<ExampleChoice>('data.py')
+    const { route, setRoute } = useRoute()
+    if (route.page !== 'prototypes') {
+        throw new Error('Unexpected route')
+    }
+
+    const selection = route.selection
+    const setSelection = useCallback((selection: 'data.py' | 'data.r' | 'analysis.py') => {
+        setRoute({page: 'prototypes', selection})
+    }, [setRoute])
 
     return (
         <div style={{position: 'absolute', width, height, overflow: 'hidden', background: 'white'}}>
@@ -23,19 +30,19 @@ const PrototypesWindow: FunctionComponent<TestDataPyWindowProps> = ({width, heig
                         Please make a selection
                     </p>
                     <div>
-                        <input type="radio" id="data.py" name="example" value="data.py" checked={exampleChoice === 'data.py'} onChange={() => setExampleChoice('data.py')} />
+                        <input type="radio" id="data.py" name="example" value="data.py" checked={selection === 'data.py'} onChange={() => setSelection('data.py')} />
                         <label htmlFor="data.py">data.py</label>
                     </div>
                     <div>
-                        <input type="radio" id="data.r" name="example" value="data.r" checked={exampleChoice === 'data.r'} onChange={() => setExampleChoice('data.r')} />
+                        <input type="radio" id="data.r" name="example" value="data.r" checked={selection === 'data.r'} onChange={() => setSelection('data.r')} />
                         <label htmlFor="data.r">data.r</label>
                     </div>
                     <div>
-                        <input type="radio" id="analysis.py" name="example" value="analysis.py" checked={exampleChoice === 'analysis.py'} onChange={() => setExampleChoice('analysis.py')} />
+                        <input type="radio" id="analysis.py" name="example" value="analysis.py" checked={selection === 'analysis.py'} onChange={() => setSelection('analysis.py')} />
                         <label htmlFor="analysis.py">analysis.py</label>
                     </div>
                     {
-                        exampleChoice === 'data.py' ? (
+                        selection === 'data.py' ? (
                             <div>
                                 <p>
                                     This is an example of how data generation via Python script might work. It uses Pyodide in the browser.
@@ -44,7 +51,7 @@ const PrototypesWindow: FunctionComponent<TestDataPyWindowProps> = ({width, heig
                                     The value of the global variable <code>data</code> is used to pass data from the Python script to the output window.
                                 </p>
                             </div>
-                        ) : exampleChoice === 'data.r' ? (
+                        ) : selection === 'data.r' ? (
                             <div>
                                 <p>
                                     This is an example of how data generation via R script might work. It uses webr in the browser.
@@ -53,10 +60,10 @@ const PrototypesWindow: FunctionComponent<TestDataPyWindowProps> = ({width, heig
                                     The value of the global variable <code>data</code> is used to pass data from the R script to the output window.
                                 </p>
                             </div>
-                        ) : exampleChoice === 'analysis.py' ? (
+                        ) : selection === 'analysis.py' ? (
                             <div>
                                 <p>
-                                    Not yet implemented.
+                                    This is an example of how downstream analysis via Python script might work. It uses Pyodide in the browser.
                                 </p>
                             </div>
                         ) : <div />
@@ -65,20 +72,21 @@ const PrototypesWindow: FunctionComponent<TestDataPyWindowProps> = ({width, heig
             </div>
             <div style={{position: 'absolute', top: 0, left: leftPanelWidth, width: width - leftPanelWidth, height, overflowY: 'hidden'}}>
                 {
-                    exampleChoice === 'data.py' ? (
+                    selection === 'data.py' ? (
                         <DataPyPrototype
                             width={width - leftPanelWidth}
                             height={height}
                         />
-                    ) : exampleChoice === 'data.r' ? (
+                    ) : selection === 'data.r' ? (
                         <DataRPrototype
                             width={width - leftPanelWidth}
                             height={height}
                         />
-                    ) : exampleChoice === 'analysis.py' ? (
-                        <div>
-                            Not yet implemented
-                        </div>
+                    ) : selection === 'analysis.py' ? (
+                        <AnalysisPyPrototype
+                            width={width - leftPanelWidth}
+                            height={height}
+                        />
                     ) : <div />
                 }
             </div>

--- a/gui/src/app/pages/HomePage/TopBar.tsx
+++ b/gui/src/app/pages/HomePage/TopBar.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { FunctionComponent } from "react";
 import CompilationServerConnectionControl from "../../CompilationServerConnectionControl/CompilationServerConnectionControl";
-import { SmallIconButton } from "@fi-sci/misc";
+import { Hyperlink, SmallIconButton } from "@fi-sci/misc";
 import { QuestionMark } from "@mui/icons-material";
 import useRoute from "../../useRoute";
 import { Toolbar } from "@mui/material";
@@ -23,6 +23,7 @@ const TopBar: FunctionComponent<TopBarProps> = () => {
     <div>
       <Toolbar style={{minHeight: 20}}>
         Stan Playground - {localDataModel.title}
+        &nbsp;<Hyperlink onClick={() => setRoute({page: 'prototypes'})} color="lightblue">[View prototypes]</Hyperlink>
         <span style={{marginLeft: 'auto'}} />
         <CompilationServerConnectionControl />
         <span>

--- a/gui/src/app/useRoute.ts
+++ b/gui/src/app/useRoute.ts
@@ -11,6 +11,8 @@ export type Route = {
         inline_sampling_opts?: SamplingOpts
         title?: string
     }
+} | {
+    page: 'prototypes'
 }
 
 const useRoute = () => {
@@ -19,6 +21,9 @@ const useRoute = () => {
     const search = location.search
     const query = useMemo(() => (parseSearchString(search)), [search])
     const route: Route = useMemo(() => {
+        if (query.page === 'prototypes') {
+            return { page: 'prototypes' }
+        }
         const recognizedQueryKeys = new Set([
             'stan',
             'data',
@@ -78,8 +83,12 @@ const useRoute = () => {
 
     const setRoute = useCallback((r: Route, replaceHistory?: boolean) => {
         let newQuery: { [key: string]: string | undefined } | undefined = undefined
+        if (r.page === 'prototypes') {
+            navigate(location.pathname + '?page=prototypes', {replace: replaceHistory})
+            return
+        }
         if (r.page != 'home') {
-            console.error('Unexpected page in setRoute', r.page)
+            console.error('Unexpected page in setRoute', (r as any).page)
             return
         }
         if (r.sourceDataQuery) {

--- a/gui/src/app/useRoute.ts
+++ b/gui/src/app/useRoute.ts
@@ -13,6 +13,7 @@ export type Route = {
     }
 } | {
     page: 'prototypes'
+    selection: 'data.py' | 'data.r' | 'analysis.py'
 }
 
 const useRoute = () => {
@@ -22,7 +23,10 @@ const useRoute = () => {
     const query = useMemo(() => (parseSearchString(search)), [search])
     const route: Route = useMemo(() => {
         if (query.page === 'prototypes') {
-            return { page: 'prototypes' }
+            return {
+                page: 'prototypes',
+                selection: (query.selection || 'data.py') as 'data.py' | 'data.r' | 'analysis.py'
+            }
         }
         const recognizedQueryKeys = new Set([
             'stan',
@@ -84,7 +88,7 @@ const useRoute = () => {
     const setRoute = useCallback((r: Route, replaceHistory?: boolean) => {
         let newQuery: { [key: string]: string | undefined } | undefined = undefined
         if (r.page === 'prototypes') {
-            navigate(location.pathname + '?page=prototypes', {replace: replaceHistory})
+            navigate(location.pathname + `?page=prototypes&selection=${r.selection}`, {replace: replaceHistory})
             return
         }
         if (r.page != 'home') {

--- a/gui/yarn.lock
+++ b/gui/yarn.lock
@@ -240,6 +240,70 @@
   dependencies:
     commander "^2.15.1"
 
+"@codemirror/autocomplete@^6.0.0", "@codemirror/autocomplete@^6.8.1":
+  version "6.16.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/autocomplete/-/autocomplete-6.16.2.tgz#ac4e191cd599503e45f35e97366b432d30b8f37a"
+  integrity sha512-MjfDrHy0gHKlPWsvSsikhO1+BOh+eBHNgfH1OXs1+DAf30IonQldgMM3kxLDTG9ktE7kDLaA1j/l7KMPA4KNfw==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.17.0"
+    "@lezer/common" "^1.0.0"
+
+"@codemirror/commands@^6.0.0", "@codemirror/commands@^6.2.4":
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/commands/-/commands-6.6.0.tgz#d308f143fe1b8896ca25fdb855f66acdaf019dd4"
+  integrity sha512-qnY+b7j1UNcTS31Eenuc/5YJB6gQOzkUoNmJQc0rznwqSRpeaWWpjkWy2C/MPTcePpsKJEM26hXrOXl1+nceXg==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.4.0"
+    "@codemirror/view" "^6.27.0"
+    "@lezer/common" "^1.1.0"
+
+"@codemirror/language@^6.0.0":
+  version "6.10.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/language/-/language-6.10.2.tgz#4056dc219619627ffe995832eeb09cea6060be61"
+  integrity sha512-kgbTYTo0Au6dCSc/TFy7fK3fpJmgHDv1sG1KNQKJXVi+xBTEeBPY/M30YXiU6mMXeH+YIDLsbrT4ZwNRdtF+SA==
+  dependencies:
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.23.0"
+    "@lezer/common" "^1.1.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+    style-mod "^4.0.0"
+
+"@codemirror/lint@^6.0.0":
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/lint/-/lint-6.8.0.tgz#cf9067c7041c1f6c9f20bab411dac9323aab54f0"
+  integrity sha512-lsFofvaw0lnPRJlQylNsC4IRt/1lI4OD/yYslrSGVndOJfStc58v+8p9dgGiD90ktOfL7OhBWns1ZETYgz0EJA==
+  dependencies:
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+    crelt "^1.0.5"
+
+"@codemirror/search@^6.0.0":
+  version "6.5.6"
+  resolved "https://registry.yarnpkg.com/@codemirror/search/-/search-6.5.6.tgz#8f858b9e678d675869112e475f082d1e8488db93"
+  integrity sha512-rpMgcsh7o0GuCDUXKPvww+muLA1pDJaFrpq/CCHtpQJYz8xopu4D1hPcKRoDD0YlF8gZaqTNIRa4VRBWyhyy7Q==
+  dependencies:
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+    crelt "^1.0.5"
+
+"@codemirror/state@^6.0.0", "@codemirror/state@^6.2.1", "@codemirror/state@^6.4.0":
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/state/-/state-6.4.1.tgz#da57143695c056d9a3c38705ed34136e2b68171b"
+  integrity sha512-QkEyUiLhsJoZkbumGZlswmAhA7CBU02Wrz7zvH4SrcifbsqwlXShVXg65f3v/ts57W3dqyamEriMhij1Z3Zz4A==
+
+"@codemirror/view@^6.0.0", "@codemirror/view@^6.15.0", "@codemirror/view@^6.17.0", "@codemirror/view@^6.23.0", "@codemirror/view@^6.27.0":
+  version "6.28.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-6.28.1.tgz#566b89b0513ccfc4e5518a48f5d1962bc6ea5a66"
+  integrity sha512-BUWr+zCJpMkA/u69HlJmR+YkV4yPpM81HeMkOMZuwFa8iM5uJdEPKAs1icIRZKkKmy0Ub1x9/G3PQLTXdpBxrQ==
+  dependencies:
+    "@codemirror/state" "^6.4.0"
+    style-mod "^4.1.0"
+    w3c-keyname "^2.2.4"
+
 "@emotion/babel-plugin@^11.11.0":
   version "11.11.0"
   resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.11.0.tgz#c2d872b6a7767a9d176d007f5b31f7d504bb5d6c"
@@ -604,6 +668,25 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@lezer/common@^1.0.0", "@lezer/common@^1.1.0":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@lezer/common/-/common-1.2.1.tgz#198b278b7869668e1bebbe687586e12a42731049"
+  integrity sha512-yemX0ZD2xS/73llMZIK6KplkjIjf2EvAHcinDi/TfJ9hS25G0388+ClHt6/3but0oOxinTcQHJLDXh6w1crzFQ==
+
+"@lezer/highlight@^1.0.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@lezer/highlight/-/highlight-1.2.0.tgz#e5898c3644208b4b589084089dceeea2966f7780"
+  integrity sha512-WrS5Mw51sGrpqjlh3d4/fOwpEV2Hd3YOkp9DBt4k8XZQcoTHZFB7sx030A6OcahF4J1nDQAa3jXlTVVYH50IFA==
+  dependencies:
+    "@lezer/common" "^1.0.0"
+
+"@lezer/lr@^1.0.0":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@lezer/lr/-/lr-1.4.1.tgz#fe25f051880a754e820b28148d90aa2a96b8bdd2"
+  integrity sha512-CHsKq8DMKBf9b3yXPDIU4DbH+ZJd/sJdYOW2llbW/HudP5u0VS6Bfq1hLYfgU7uAYGFIyGGQIsSOXGPEErZiJw==
+  dependencies:
+    "@lezer/common" "^1.0.0"
+
 "@mapbox/geojson-rewind@^0.5.2":
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz#591a5d71a9cd1da1a0bf3420b3bea31b0fc7946a"
@@ -667,6 +750,11 @@
   integrity sha512-RFkU9/i7cN2bsq/iTkurMWOEErmYcY6JiQI3Jn+WeR/FGISH8JbHERjpS9oRuSOPvDMJI0Z8nJeKkbOs9sBYQw==
   dependencies:
     "@monaco-editor/loader" "^1.4.0"
+
+"@msgpack/msgpack@^2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@msgpack/msgpack/-/msgpack-2.8.0.tgz#4210deb771ee3912964f14a15ddfb5ff877e70b9"
+  integrity sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ==
 
 "@mui/base@5.0.0-beta.40":
   version "5.0.0-beta.40"
@@ -1761,6 +1849,11 @@ clamp@^1.0.1:
   resolved "https://registry.yarnpkg.com/clamp/-/clamp-1.0.1.tgz#66a0e64011816e37196828fdc8c8c147312c8634"
   integrity sha512-kgMuFyE78OC6Dyu3Dy7vcx4uy97EIbVxJB/B0eJ3bUNAkwdNcxYzgKltnyADiYwsR7SEqkkUPsEUT//OVS6XMA==
 
+classnames@^2.2.6:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.5.1.tgz#ba774c614be0f016da105c858e7159eae8e7687b"
+  integrity sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==
+
 clsx@^1.1.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
@@ -1770,6 +1863,27 @@ clsx@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
   integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
+
+codemirror-lang-r@^0.1.0-2:
+  version "0.1.0-2"
+  resolved "https://registry.yarnpkg.com/codemirror-lang-r/-/codemirror-lang-r-0.1.0-2.tgz#921100e5a1fce834b2ea18a4a29b6ed563bb69c5"
+  integrity sha512-36eOC69k1Fb75pfjF0L00mGDxprWIuB45rK8isL+p0xAVRyb51j2fI8M8OUQNc7B1cRi5rnWXATXyRKOuaCE3g==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    lezer-r "^0.1.0-5"
+
+codemirror@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-6.0.1.tgz#62b91142d45904547ee3e0e0e4c1a79158035a29"
+  integrity sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/commands" "^6.0.0"
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/lint" "^6.0.0"
+    "@codemirror/search" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
 
 color-alpha@1.0.4:
   version "1.0.4"
@@ -1959,6 +2073,11 @@ country-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/country-regex/-/country-regex-1.1.0.tgz#51c333dcdf12927b7e5eeb9c10ac8112a6120896"
   integrity sha512-iSPlClZP8vX7MC3/u6s3lrDuoQyhQukh5LyABJ3hvfzbQ3Yyayd4fp04zjLnfi267B/B2FkumcWWgrbban7sSA==
+
+crelt@^1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/crelt/-/crelt-1.0.6.tgz#7cc898ea74e190fb6ef9dae57f8f81cf7302df72"
+  integrity sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==
 
 cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
@@ -2263,6 +2382,11 @@ detect-kerning@^2.1.2:
   resolved "https://registry.yarnpkg.com/detect-kerning/-/detect-kerning-2.1.2.tgz#4ecd548e4a5a3fc880fe2a50609312d000fa9fc2"
   integrity sha512-I3JIbrnKPAntNLl1I6TpSQQdQ4AutYzv/sKMFKbepawV/hlH0GmYKhUoOEMd4xqaUHT+Bm0f4127lh5qs1m1tw==
 
+detect-libc@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
+  integrity sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==
+
 devlop@^1.0.0, devlop@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/devlop/-/devlop-1.1.0.tgz#4db7c2ca4dc6e0e834c30be70c94bbc976dc7018"
@@ -2363,6 +2487,11 @@ elementary-circuits-directed-graph@^1.0.4:
   integrity sha512-ZEiB5qkn2adYmpXGnJKkxT8uJHlW/mxmBpmeqawEHzPxh9HkLD4/1mFYX5l0On+f6rcPIt8/EWlRU2Vo3fX6dQ==
   dependencies:
     strongly-connected-components "^1.0.1"
+
+emoji-regex@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
 end-of-stream@^1.0.0:
   version "1.4.4"
@@ -2536,7 +2665,7 @@ es6-weak-map@^2.0.3:
     es6-iterator "^2.0.3"
     es6-symbol "^3.1.1"
 
-esbuild@^0.21.3:
+esbuild@^0.21.3, esbuild@~0.21.4:
   version "0.21.5"
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.21.5.tgz#9ca301b120922959b766360d8ac830da0d02997d"
   integrity sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==
@@ -3012,6 +3141,13 @@ get-symbol-description@^1.0.2:
     call-bind "^1.0.5"
     es-errors "^1.3.0"
     get-intrinsic "^1.2.4"
+
+get-tsconfig@^4.7.5:
+  version "4.7.5"
+  resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.7.5.tgz#5e012498579e9a6947511ed0cd403272c7acbbaf"
+  integrity sha512-ZCuZCnlqNzjb4QprAzXKdpp/gh6KTxSJuw3IBsPnV/7fV4NxC9ckB+vPTt8w7fJA0TaSD7c55BR47JD6MEDyDw==
+  dependencies:
+    resolve-pkg-maps "^1.0.0"
 
 gl-mat4@^1.2.0:
   version "1.2.0"
@@ -3686,6 +3822,11 @@ is-firefox@^1.0.3:
   resolved "https://registry.yarnpkg.com/is-firefox/-/is-firefox-1.0.3.tgz#2a2a1567783a417f6e158323108f3861b0918562"
   integrity sha512-6Q9ITjvWIm0Xdqv+5U12wgOKEM2KoBw4Y926m0OFkvlCxnbG94HKAsVz8w3fWcfAS5YA2fJORXX1dLrkprCCxA==
 
+is-fullwidth-code-point@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
+
 is-generator-function@^1.0.10:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.0.10.tgz#f1558baf1ac17e0deea7c0415c438351ff2b3c72"
@@ -4053,12 +4194,82 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
+lezer-r@^0.1.0-5:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/lezer-r/-/lezer-r-0.1.1.tgz#228db848928cdc700712eabe3f845ebd27b80030"
+  integrity sha512-bIBHtedC6VtdYpsj7q6OO/CiU7rQkNOUJPi3EmqlpxW/Vv/R8jJI6Lr8jRqsSqZZD5GslLsYdrx3mXvvDv3xAg==
+  dependencies:
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+
 lie@~3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
   integrity sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==
   dependencies:
     immediate "~3.0.5"
+
+lightningcss-darwin-arm64@1.25.1:
+  version "1.25.1"
+  resolved "https://registry.yarnpkg.com/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.25.1.tgz#f2943d6dc1a4d331de0ff9ad54cd03cf10e0ead3"
+  integrity sha512-G4Dcvv85bs5NLENcu/s1f7ehzE3D5ThnlWSDwE190tWXRQCQaqwcuHe+MGSVI/slm0XrxnaayXY+cNl3cSricw==
+
+lightningcss-darwin-x64@1.25.1:
+  version "1.25.1"
+  resolved "https://registry.yarnpkg.com/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.25.1.tgz#dc5d2d5c4372308b1a326a8c5efcc3e489b654c6"
+  integrity sha512-dYWuCzzfqRueDSmto6YU5SoGHvZTMU1Em9xvhcdROpmtOQLorurUZz8+xFxZ51lCO2LnYbfdjZ/gCqWEkwixNg==
+
+lightningcss-freebsd-x64@1.25.1:
+  version "1.25.1"
+  resolved "https://registry.yarnpkg.com/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.25.1.tgz#bb37f25c2d136ff33b25dd08bee5e167afacc49c"
+  integrity sha512-hXoy2s9A3KVNAIoKz+Fp6bNeY+h9c3tkcx1J3+pS48CqAt+5bI/R/YY4hxGL57fWAIquRjGKW50arltD6iRt/w==
+
+lightningcss-linux-arm-gnueabihf@1.25.1:
+  version "1.25.1"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.25.1.tgz#b5395b55fb8a4cea87e2723c5c61a5124a0d4c42"
+  integrity sha512-tWyMgHFlHlp1e5iW3EpqvH5MvsgoN7ZkylBbG2R2LWxnvH3FuWCJOhtGcYx9Ks0Kv0eZOBud789odkYLhyf1ng==
+
+lightningcss-linux-arm64-gnu@1.25.1:
+  version "1.25.1"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.25.1.tgz#4303c196d8d32b66b6a2f7c939c938bd0f138f75"
+  integrity sha512-Xjxsx286OT9/XSnVLIsFEDyDipqe4BcLeB4pXQ/FEA5+2uWCCuAEarUNQumRucnj7k6ftkAHUEph5r821KBccQ==
+
+lightningcss-linux-arm64-musl@1.25.1:
+  version "1.25.1"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.25.1.tgz#f45d7c832bb9c73a13dfc59c8de4692f7e47040a"
+  integrity sha512-IhxVFJoTW8wq6yLvxdPvyHv4NjzcpN1B7gjxrY3uaykQNXPHNIpChLB52+wfH+yS58zm1PL4LemUp8u9Cfp6Bw==
+
+lightningcss-linux-x64-gnu@1.25.1:
+  version "1.25.1"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.25.1.tgz#a0836d5d25601ea8ef23292a748ea9e52d5bc086"
+  integrity sha512-RXIaru79KrREPEd6WLXfKfIp4QzoppZvD3x7vuTKkDA64PwTzKJ2jaC43RZHRt8BmyIkRRlmywNhTRMbmkPYpA==
+
+lightningcss-linux-x64-musl@1.25.1:
+  version "1.25.1"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.25.1.tgz#6f92021bae952645fe297bea10467c3cccba0138"
+  integrity sha512-TdcNqFsAENEEFr8fJWg0Y4fZ/nwuqTRsIr7W7t2wmDUlA8eSXVepeeONYcb+gtTj1RaXn/WgNLB45SFkz+XBZA==
+
+lightningcss-win32-x64-msvc@1.25.1:
+  version "1.25.1"
+  resolved "https://registry.yarnpkg.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.25.1.tgz#1431840070e5976d5c5b06e44e4304606a01fb05"
+  integrity sha512-9KZZkmmy9oGDSrnyHuxP6iMhbsgChUiu/NSgOx+U1I/wTngBStDf2i2aGRCHvFqj19HqqBEI4WuGVQBa2V6e0A==
+
+lightningcss@^1.21.5:
+  version "1.25.1"
+  resolved "https://registry.yarnpkg.com/lightningcss/-/lightningcss-1.25.1.tgz#6136c166ac61891fbc1af7fba7b620c50f58fb2d"
+  integrity sha512-V0RMVZzK1+rCHpymRv4URK2lNhIRyO8g7U7zOFwVAhJuat74HtkjIQpQRKNCwFEYkRGpafOpmXXLoaoBcyVtBg==
+  dependencies:
+    detect-libc "^1.0.3"
+  optionalDependencies:
+    lightningcss-darwin-arm64 "1.25.1"
+    lightningcss-darwin-x64 "1.25.1"
+    lightningcss-freebsd-x64 "1.25.1"
+    lightningcss-linux-arm-gnueabihf "1.25.1"
+    lightningcss-linux-arm64-gnu "1.25.1"
+    lightningcss-linux-arm64-musl "1.25.1"
+    lightningcss-linux-x64-gnu "1.25.1"
+    lightningcss-linux-x64-musl "1.25.1"
+    lightningcss-win32-x64-msvc "1.25.1"
 
 lines-and-columns@^1.1.6:
   version "1.2.4"
@@ -5472,6 +5683,13 @@ punycode@^2.1.0, punycode@^2.1.1, punycode@^2.3.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
+pyodide@^0.26.1:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/pyodide/-/pyodide-0.26.1.tgz#1c7f152550e827beebf8db34d11b236a6958b1ae"
+  integrity sha512-P+Gm88nwZqY7uBgjbQH8CqqU6Ei/rDn7pS1t02sNZsbyLJMyE2OVXjgNuqVT3KqYWnyGREUN0DbBUCJqk8R0ew==
+  dependencies:
+    ws "^8.5.0"
+
 querystringify@^2.1.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
@@ -5494,6 +5712,11 @@ raf@^3.4.1:
   dependencies:
     performance-now "^2.1.0"
 
+react-accessible-treeview@^2.6.1:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/react-accessible-treeview/-/react-accessible-treeview-2.9.1.tgz#9b2646b05989f269332b00fa7168d594120e42d4"
+  integrity sha512-UlmeFJtlh1SryN8kHLf4ICLlF4HeIpiacWwHh+7AzhmOmOs9vObXAjJWTiLpxP342TQ1QbCdSGq086Y8oD7NSw==
+
 react-dom@^18.2.0:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.3.1.tgz#c2265d79511b57d479b3dd3fdfa51536494c5cb4"
@@ -5509,6 +5732,11 @@ react-draggable@^4.4.6:
   dependencies:
     clsx "^1.1.1"
     prop-types "^15.8.1"
+
+react-icons@^4.10.1:
+  version "4.12.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.12.0.tgz#54806159a966961bfd5cdb26e492f4dafd6a8d78"
+  integrity sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==
 
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
@@ -5841,6 +6069,11 @@ resolve-from@^4.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
+resolve-pkg-maps@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz#616b3dc2c57056b5588c31cdf4b3d64db133720f"
+  integrity sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==
+
 resolve-protobuf-schema@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz#9ca9a9e69cf192bbdaf1006ec1973948aa4a3758"
@@ -6159,6 +6392,15 @@ string-split-by@^1.0.0:
   dependencies:
     parenthesis "^3.1.5"
 
+string-width@^4.0.0:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
 string.prototype.matchall@^4.0.11:
   version "4.0.11"
   resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.11.tgz#1092a72c59268d2abaad76582dccc687c0297e0a"
@@ -6245,6 +6487,11 @@ strongly-connected-components@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/strongly-connected-components/-/strongly-connected-components-1.0.1.tgz#0920e2b4df67c8eaee96c6b6234fe29e873dba99"
   integrity sha512-i0TFx4wPcO0FwX+4RkLJi1MxmcTv90jNZgxMu9XRnMXMeFUY1VJlIoXpZunPUvUUqbCT1pg5PEkFqqpcaElNaA==
+
+style-mod@^4.0.0, style-mod@^4.1.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/style-mod/-/style-mod-4.1.2.tgz#ca238a1ad4786520f7515a8539d5a63691d7bf67"
+  integrity sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==
 
 style-to-object@^0.4.0:
   version "0.4.4"
@@ -6449,6 +6696,16 @@ ts-api-utils@^1.0.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-1.3.0.tgz#4b490e27129f1e8e686b45cc4ab63714dc60eea1"
   integrity sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==
+
+tsx@^4.0.0:
+  version "4.15.6"
+  resolved "https://registry.yarnpkg.com/tsx/-/tsx-4.15.6.tgz#4522ed093f7fa54f031a7a999274e8b35dbf3165"
+  integrity sha512-is0VQQlfNZRHEuSSTKA6m4xw74IU4AizmuB6lAYLRt9XtuyeQnyJYexhNZOPCB59SqC4JzmSzPnHGBXxf3k0hA==
+  dependencies:
+    esbuild "~0.21.4"
+    get-tsconfig "^4.7.5"
+  optionalDependencies:
+    fsevents "~2.3.3"
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
@@ -6823,6 +7080,11 @@ vt-pbf@^3.1.1:
     "@mapbox/vector-tile" "^1.3.1"
     pbf "^3.2.1"
 
+w3c-keyname@^2.2.4:
+  version "2.2.8"
+  resolved "https://registry.yarnpkg.com/w3c-keyname/-/w3c-keyname-2.2.8.tgz#7b17c8c6883d4e8b86ac8aba79d39e880f8869c5"
+  integrity sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==
+
 w3c-xmlserializer@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz#f925ba26855158594d907313cedd1476c5967f6c"
@@ -6851,6 +7113,31 @@ webidl-conversions@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
   integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
+
+webr@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/webr/-/webr-0.3.3.tgz#4250de03fd1bd880b5f7394a7bd3e3db458b4068"
+  integrity sha512-SMl7FV1L1/KHzSOZ46WYscAbG8NIb7krMtVWQgTsVcHUeVeqQoFx+asMWvVXOCCRleypulRrP5lI4vDhr7vnuQ==
+  dependencies:
+    "@codemirror/autocomplete" "^6.8.1"
+    "@codemirror/commands" "^6.2.4"
+    "@codemirror/state" "^6.2.1"
+    "@codemirror/view" "^6.15.0"
+    "@msgpack/msgpack" "^2.8.0"
+    classnames "^2.2.6"
+    codemirror "^6.0.1"
+    codemirror-lang-r "^0.1.0-2"
+    lightningcss "^1.21.5"
+    prop-types "^15.7.2"
+    react "^18.2.0"
+    react-accessible-treeview "^2.6.1"
+    react-dom "^18.2.0"
+    react-icons "^4.10.1"
+    tsx "^4.0.0"
+    xmlhttprequest-ssl "^2.1.0"
+    xterm "^5.1.0"
+    xterm-addon-fit "^0.7.0"
+    xterm-readline "^1.1.1"
 
 whatwg-encoding@^3.1.1:
   version "3.1.1"
@@ -6959,7 +7246,7 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-ws@^8.16.0, ws@^8.17.0:
+ws@^8.16.0, ws@^8.17.0, ws@^8.5.0:
   version "8.17.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.17.0.tgz#d145d18eca2ed25aaf791a183903f7be5e295fea"
   integrity sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==
@@ -6979,6 +7266,11 @@ xmldom-sre@0.1.31:
   resolved "https://registry.yarnpkg.com/xmldom-sre/-/xmldom-sre-0.1.31.tgz#10860d5bab2c603144597d04bf2c4980e98067f4"
   integrity sha512-f9s+fUkX04BxQf+7mMWAp5zk61pciie+fFLC9hX9UVvCeJQfNHRHXpeo5MPcR0EUf57PYLdt+ZO4f3Ipk2oZUw==
 
+xmlhttprequest-ssl@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.1.tgz#0d045c3b2babad8e7db1af5af093f5d0d60df99a"
+  integrity sha512-ptjR8YSJIXoA3Mbv5po7RtSYHO6mZr8s7i5VGmEk7QY2pQWyT1o0N+W1gKbOyJPUCGXGnuw0wqe8f0L6Y0ny7g==
+
 "xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
@@ -6988,6 +7280,23 @@ xtend@^2.1.2:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-2.2.0.tgz#eef6b1f198c1c8deafad8b1765a04dad4a01c5a9"
   integrity sha512-SLt5uylT+4aoXxXuwtQp5ZnMMzhDb1Xkg4pEqc00WUJCQifPfV9Ub1VrNhp9kXkrjZD2I2Hl8WnjP37jzZLPZw==
+
+xterm-addon-fit@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/xterm-addon-fit/-/xterm-addon-fit-0.7.0.tgz#b8ade6d96e63b47443862088f6670b49fb752c6a"
+  integrity sha512-tQgHGoHqRTgeROPnvmtEJywLKoC/V9eNs4bLLz7iyJr1aW/QFzRwfd3MGiJ6odJd9xEfxcW36/xRU47JkD5NKQ==
+
+xterm-readline@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/xterm-readline/-/xterm-readline-1.1.1.tgz#781dacf883283cfec1a7845fae50beba3716aa04"
+  integrity sha512-f87S2/jKwRZoZTxE2vkPgBCipDl6k6tTkMTb9pmwC4R6XkfR491fWBuToZd/nZasp6seD2u0jdABinUDWsK6dw==
+  dependencies:
+    string-width "^4.0.0"
+
+xterm@^5.1.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/xterm/-/xterm-5.3.0.tgz#867daf9cc826f3d45b5377320aabd996cb0fce46"
+  integrity sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==
 
 yallist@^3.0.2:
   version "3.1.1"


### PR DESCRIPTION
Replaces #26 and #27

Built on #65 because that provides a clean starting point for routes.

This provides prototypes for data.py and data.r data generation via pyodide and webr. These can be viewed in the page=prototypes route by clicking on the "view prototypes" link in the menu bar as shown:

![image](https://github.com/flatironinstitute/stan-playground/assets/3679296/50616c22-3138-409f-b19a-e9e6c76d161b)

You can select which prototype to view in the left panel

![image](https://github.com/flatironinstitute/stan-playground/assets/3679296/1cf28329-905f-4666-a64e-5f9adf5437c2)

The data.py and data.r examples include example scripts for generating the data.json