### PR TITLE
Reintroduce formatting for stanie data file

### DIFF
--- a/gui/src/app/SPAnalysis/SPAnalysisReducer.ts
+++ b/gui/src/app/SPAnalysis/SPAnalysisReducer.ts
@@ -32,16 +32,17 @@ export type SPAnalysisReducerAction = {
 export const SPAnalysisReducer: SPAnalysisReducerType = (s: SPAnalysisDataModel, a: SPAnalysisReducerAction) => {
     switch (a.type) {
         case "loadStanie": {
+            const dataFileContent = JSON.stringify(a.stanie.data, null, 2);
             return {
                 ...s,
                 stanFileContent: a.stanie.stan,
-                dataFileContent: JSON.stringify(a.stanie.data),
+                dataFileContent,
                 samplingOpts: defaultSamplingOpts,
                 meta: { ...s.meta, title: a.stanie.meta.title ?? 'Untitled' },
                 ephemera: {
                     ...s.ephemera,
                     stanFileContent: a.stanie.stan,
-                    dataFileContent: JSON.stringify(a.stanie.data)
+                    dataFileContent,
                 }
             }
         }


### PR DESCRIPTION
While reviewing #80 I noticed that the Stan example data was being loaded in all on one long line 