### PR TITLE
Basic query loading

### DIFF
--- a/gui/src/app/SPAnalysis/SPAnalysisContextProvider.tsx
+++ b/gui/src/app/SPAnalysis/SPAnalysisContextProvider.tsx
@@ -1,6 +1,8 @@
 import { createContext, FunctionComponent, PropsWithChildren, useEffect, useReducer } from "react"
-import { initialDataModel, SPAnalysisDataModel } from "./SPAnalysisDataModel"
+import {  initialDataModel, SPAnalysisDataModel, modelHasUnsavedChanges } from "./SPAnalysisDataModel"
 import { SPAnalysisReducer, SPAnalysisReducerAction, SPAnalysisReducerType } from "./SPAnalysisReducer"
+import { useSearchParams } from "react-router-dom"
+import { SamplingOpts } from "../StanSampler/StanSampler"
 import { deserializeAnalysisFromLocalStorage, serializeAnalysisToLocalStorage } from "./SPAnalysisSerialization"
 
 type SPAnalysisContextType = {
@@ -13,11 +15,112 @@ type SPAnalysisContextProviderProps = {
 
 export const SPAnalysisContext = createContext<SPAnalysisContextType>({
     data: initialDataModel,
-    update: () => {}
+    update: () => { }
 })
 
-const SPAnalysisContextProvider: FunctionComponent<PropsWithChildren<SPAnalysisContextProviderProps>> = ({children}) => {
+
+enum QueryParamKeys {
+    StanFile = "stan",
+    DataFile = "data",
+    SamplingOpts = "sampling_opts",
+    Title = "title",
+    SONumChains = 'num_chains',
+    SONumWarmup = 'num_warmup',
+    SONumSamples = 'num_samples',
+    SOInitRadius = 'init_radius',
+    SOSeed = 'seed',
+}
+
+type QueryParams = {
+    [key in QueryParamKeys]: string | null
+}
+
+const fromSearchParams = (searchParams: URLSearchParams) => {
+    const query: QueryParams = {
+        stan: searchParams.get(QueryParamKeys.StanFile),
+        data: searchParams.get(QueryParamKeys.DataFile),
+        sampling_opts: searchParams.get(QueryParamKeys.SamplingOpts),
+        title: searchParams.get(QueryParamKeys.Title),
+        num_chains: searchParams.get(QueryParamKeys.SONumChains),
+        num_warmup: searchParams.get(QueryParamKeys.SONumWarmup),
+        num_samples: searchParams.get(QueryParamKeys.SONumSamples),
+        init_radius: searchParams.get(QueryParamKeys.SOInitRadius),
+        seed: searchParams.get(QueryParamKeys.SOSeed),
+    }
+    return query
+
+}
+
+
+const tryFetch = async (url: string) => {
+    console.log('Fetching content from', url);
+    try {
+        const req = await fetch(url);
+        if (!req.ok) {
+            console.error('Failed to fetch from url', url, req.status, req.statusText);
+            return undefined;
+        }
+        return await req.text();
+    } catch (err) {
+        console.error('Failed to fetch from url', url, err);
+        return undefined;
+    }
+}
+
+const deepCopy = (obj: any) => {
+    return JSON.parse(JSON.stringify(obj))
+}
+
+const fetchRemoteAnalysis = async (query: QueryParams) => {
+
+    // any special 'project' query could be loaded here at the top
+    const data: SPAnalysisDataModel = deepCopy(initialDataModel);
+
+    if (query.stan) {
+        const stanFileContent = await tryFetch(query.stan);
+        if (stanFileContent) {
+            data.stanFileContent = stanFileContent;
+        }
+    }
+    if (query.data) {
+        const dataFileContent = await tryFetch(query.data);
+        if (dataFileContent) {
+            data.dataFileContent = dataFileContent;
+        }
+    }
+
+    if (query.sampling_opts) {
+        const text = await tryFetch(query.sampling_opts);
+        if (text) {
+            // TODO(bmw) validate
+            data.samplingOpts = JSON.parse(text);
+        }
+    } else {
+        for (const k in Object.keys(data.samplingOpts)) {
+            const key = k as keyof SamplingOpts;
+            const setting = query[key];
+            if (setting) {
+                data.samplingOpts[key] = parseInt(setting);
+            }
+        }
+    }
+
+    if (query.title) {
+        data.meta.title = query.title;
+    }
+
+    // TODO(bmw) create a 'setEphemera' helper?
+    data.ephemera.stanFileContent = data.stanFileContent;
+    data.ephemera.dataFileContent = data.dataFileContent;
+
+    return data;
+}
+
+
+const SPAnalysisContextProvider: FunctionComponent<PropsWithChildren<SPAnalysisContextProviderProps>> = ({ children }) => {
     const [data, update] = useReducer<SPAnalysisReducerType>(SPAnalysisReducer, initialDataModel)
+
+    const [searchParams, setSearchParams] = useSearchParams();
 
     ////////////////////////////////////////////////////////////////////////////////////////
     // For convenience, we save the state to local storage so it is available on
@@ -36,17 +139,37 @@ const SPAnalysisContextProvider: FunctionComponent<PropsWithChildren<SPAnalysisC
         };
     }, [data])
 
+
+
     useEffect(() => {
-        // load the saved state on first load
-        const savedState = localStorage.getItem('stan-playground-saved-state')
-        if (!savedState) return
-        const parsedData = deserializeAnalysisFromLocalStorage(savedState)
-        update({ type: 'loadLocalStorage', state: parsedData })
-    }, [])
+        if (data != initialDataModel) return;
+
+        const query = fromSearchParams(searchParams);
+
+        // any query is set
+        if (Object.values(query).some(v => v !== null)) {
+            fetchRemoteAnalysis(query).then((data) => {
+                update({ type: 'loadInitialData', state: data })
+            })
+        } else {
+            // load the saved state on first load
+            const savedState = localStorage.getItem('stan-playground-saved-state')
+            if (!savedState) return
+            const parsedData = deserializeAnalysisFromLocalStorage(savedState)
+            update({ type: 'loadInitialData', state: parsedData })
+        }
+
+    }, [data, searchParams])
+
+    useEffect(() => {
+        if (searchParams.size !== 0 && modelHasUnsavedChanges(data)) {
+            setSearchParams(new URLSearchParams());
+        }
+    }, [data, searchParams, setSearchParams])
     ////////////////////////////////////////////////////////////////////////////////////////
 
     return (
-        <SPAnalysisContext.Provider value={{data, update}}>
+        <SPAnalysisContext.Provider value={{ data, update }}>
             {children}
         </SPAnalysisContext.Provider>
     )

--- a/gui/src/app/SPAnalysis/SPAnalysisContextProvider.tsx
+++ b/gui/src/app/SPAnalysis/SPAnalysisContextProvider.tsx
@@ -96,12 +96,20 @@ const fetchRemoteAnalysis = async (query: QueryParams) => {
             data.samplingOpts = JSON.parse(text);
         }
     } else {
-        for (const k in Object.keys(data.samplingOpts)) {
-            const key = k as keyof SamplingOpts;
-            const setting = query[key];
-            if (setting) {
-                data.samplingOpts[key] = parseInt(setting);
-            }
+        if (query.num_chains) {
+            data.samplingOpts.num_chains = parseInt(query.num_chains);
+        }
+        if (query.num_warmup) {
+            data.samplingOpts.num_warmup = parseInt(query.num_warmup);
+        }
+        if (query.num_samples) {
+            data.samplingOpts.num_samples = parseInt(query.num_samples);
+        }
+        if (query.init_radius) {
+            data.samplingOpts.init_radius = parseFloat(query.init_radius);
+        }
+        if (query.seed) {
+            data.samplingOpts.seed = parseInt(query.seed);
         }
     }
 

--- a/gui/src/app/SPAnalysis/SPAnalysisContextProvider.tsx
+++ b/gui/src/app/SPAnalysis/SPAnalysisContextProvider.tsx
@@ -2,8 +2,8 @@ import { createContext, FunctionComponent, PropsWithChildren, useEffect, useRedu
 import {  initialDataModel, SPAnalysisDataModel, modelHasUnsavedChanges } from "./SPAnalysisDataModel"
 import { SPAnalysisReducer, SPAnalysisReducerAction, SPAnalysisReducerType } from "./SPAnalysisReducer"
 import { useSearchParams } from "react-router-dom"
-import { SamplingOpts } from "../StanSampler/StanSampler"
 import { deserializeAnalysisFromLocalStorage, serializeAnalysisToLocalStorage } from "./SPAnalysisSerialization"
+import { fromSearchParams, fetchRemoteAnalysis } from "./SPAnalysisQueryLoading"
 
 type SPAnalysisContextType = {
     data: SPAnalysisDataModel
@@ -17,112 +17,6 @@ export const SPAnalysisContext = createContext<SPAnalysisContextType>({
     data: initialDataModel,
     update: () => { }
 })
-
-
-enum QueryParamKeys {
-    StanFile = "stan",
-    DataFile = "data",
-    SamplingOpts = "sampling_opts",
-    Title = "title",
-    SONumChains = 'num_chains',
-    SONumWarmup = 'num_warmup',
-    SONumSamples = 'num_samples',
-    SOInitRadius = 'init_radius',
-    SOSeed = 'seed',
-}
-
-type QueryParams = {
-    [key in QueryParamKeys]: string | null
-}
-
-const fromSearchParams = (searchParams: URLSearchParams) => {
-    const query: QueryParams = {
-        stan: searchParams.get(QueryParamKeys.StanFile),
-        data: searchParams.get(QueryParamKeys.DataFile),
-        sampling_opts: searchParams.get(QueryParamKeys.SamplingOpts),
-        title: searchParams.get(QueryParamKeys.Title),
-        num_chains: searchParams.get(QueryParamKeys.SONumChains),
-        num_warmup: searchParams.get(QueryParamKeys.SONumWarmup),
-        num_samples: searchParams.get(QueryParamKeys.SONumSamples),
-        init_radius: searchParams.get(QueryParamKeys.SOInitRadius),
-        seed: searchParams.get(QueryParamKeys.SOSeed),
-    }
-    return query
-
-}
-
-
-const tryFetch = async (url: string) => {
-    console.log('Fetching content from', url);
-    try {
-        const req = await fetch(url);
-        if (!req.ok) {
-            console.error('Failed to fetch from url', url, req.status, req.statusText);
-            return undefined;
-        }
-        return await req.text();
-    } catch (err) {
-        console.error('Failed to fetch from url', url, err);
-        return undefined;
-    }
-}
-
-const deepCopy = (obj: any) => {
-    return JSON.parse(JSON.stringify(obj))
-}
-
-const fetchRemoteAnalysis = async (query: QueryParams) => {
-
-    // any special 'project' query could be loaded here at the top
-    const data: SPAnalysisDataModel = deepCopy(initialDataModel);
-
-    if (query.stan) {
-        const stanFileContent = await tryFetch(query.stan);
-        if (stanFileContent) {
-            data.stanFileContent = stanFileContent;
-        }
-    }
-    if (query.data) {
-        const dataFileContent = await tryFetch(query.data);
-        if (dataFileContent) {
-            data.dataFileContent = dataFileContent;
-        }
-    }
-
-    if (query.sampling_opts) {
-        const text = await tryFetch(query.sampling_opts);
-        if (text) {
-            // TODO(bmw) validate
-            data.samplingOpts = JSON.parse(text);
-        }
-    } else {
-        if (query.num_chains) {
-            data.samplingOpts.num_chains = parseInt(query.num_chains);
-        }
-        if (query.num_warmup) {
-            data.samplingOpts.num_warmup = parseInt(query.num_warmup);
-        }
-        if (query.num_samples) {
-            data.samplingOpts.num_samples = parseInt(query.num_samples);
-        }
-        if (query.init_radius) {
-            data.samplingOpts.init_radius = parseFloat(query.init_radius);
-        }
-        if (query.seed) {
-            data.samplingOpts.seed = parseInt(query.seed);
-        }
-    }
-
-    if (query.title) {
-        data.meta.title = query.title;
-    }
-
-    // TODO(bmw) create a 'setEphemera' helper?
-    data.ephemera.stanFileContent = data.stanFileContent;
-    data.ephemera.dataFileContent = data.dataFileContent;
-
-    return data;
-}
 
 
 const SPAnalysisContextProvider: FunctionComponent<PropsWithChildren<SPAnalysisContextProviderProps>> = ({ children }) => {
@@ -146,7 +40,7 @@ const SPAnalysisContextProvider: FunctionComponent<PropsWithChildren<SPAnalysisC
             window.removeEventListener('beforeunload', handleBeforeUnload);
         };
     }, [data])
-
+    ////////////////////////////////////////////////////////////////////////////////////////
 
 
     useEffect(() => {
@@ -169,12 +63,16 @@ const SPAnalysisContextProvider: FunctionComponent<PropsWithChildren<SPAnalysisC
 
     }, [data, searchParams])
 
+
     useEffect(() => {
+        // whenever the data state is 'dirty', we want to
+        // clear the URL bar as to indiciate that the viewed content is
+        // no longer what the link would point to
         if (searchParams.size !== 0 && modelHasUnsavedChanges(data)) {
             setSearchParams(new URLSearchParams());
         }
     }, [data, searchParams, setSearchParams])
-    ////////////////////////////////////////////////////////////////////////////////////////
+
 
     return (
         <SPAnalysisContext.Provider value={{ data, update }}>

--- a/gui/src/app/SPAnalysis/SPAnalysisContextProvider.tsx
+++ b/gui/src/app/SPAnalysis/SPAnalysisContextProvider.tsx
@@ -3,7 +3,7 @@ import { createContext, FunctionComponent, PropsWithChildren, useCallback, useEf
 import { SPAnalysisReducer, SPAnalysisReducerAction, SPAnalysisReducerType } from "./SPAnalysisReducer"
 import { useSearchParams } from "react-router-dom"
 import { deserializeAnalysisFromLocalStorage, serializeAnalysisToLocalStorage } from "./SPAnalysisSerialization"
-import { fromSearchParams, fetchRemoteAnalysis } from "./SPAnalysisQueryLoading"
+import { fromSearchParams, fetchRemoteAnalysis, queryStringHasParameters } from "./SPAnalysisQueryLoading"
 
 type SPAnalysisContextType = {
     data: SPAnalysisDataModel
@@ -33,10 +33,6 @@ const SPAnalysisContextProvider: FunctionComponent<PropsWithChildren<SPAnalysisC
 
     const [data, update] = useReducer<SPAnalysisReducerType>(SPAnalysisReducer(onDirty), initialDataModel)
 
-    ////////////////////////////////////////////////////////////////////////////////////////
-    // For convenience, we save the state to local storage so it is available on
-    // reload of the page But this will be revised in the future to use a more
-    // sophisticated storage mechanism.
     useEffect(() => {
         // as user reloads the page or closes the tab, save state to local storage
         const handleBeforeUnload = () => {
@@ -49,16 +45,12 @@ const SPAnalysisContextProvider: FunctionComponent<PropsWithChildren<SPAnalysisC
             window.removeEventListener('beforeunload', handleBeforeUnload);
         };
     }, [data])
-    ////////////////////////////////////////////////////////////////////////////////////////
-
 
     useEffect(() => {
         if (data != initialDataModel) return;
 
         const query = fromSearchParams(searchParams);
-
-        // any query is set
-        if (Object.values(query).some(v => v !== null)) {
+        if (queryStringHasParameters(query)) {
             fetchRemoteAnalysis(query).then((data) => {
                 update({ type: 'loadInitialData', state: data })
             })

--- a/gui/src/app/SPAnalysis/SPAnalysisQueryLoading.ts
+++ b/gui/src/app/SPAnalysis/SPAnalysisQueryLoading.ts
@@ -1,4 +1,4 @@
-import { SPAnalysisDataModel, initialDataModel } from "./SPAnalysisDataModel";
+import { SPAnalysisDataModel, initialDataModel, persistStateToEphemera } from "./SPAnalysisDataModel";
 
 
 enum QueryParamKeys {
@@ -37,7 +37,10 @@ export const fromSearchParams = (searchParams: URLSearchParams) => {
         seed: searchParams.get(QueryParamKeys.SOSeed),
     }
     return query
+}
 
+export const queryStringHasParameters = (query: QueryParams) => {
+    return Object.values(query).some(v => v !== null)
 }
 
 const tryFetch = async (url: string) => {
@@ -60,10 +63,9 @@ const deepCopy = (obj: any) => {
 }
 
 export const fetchRemoteAnalysis = async (query: QueryParams) => {
-
     // any special 'project' query could be loaded here at the top
     const data: SPAnalysisDataModel = deepCopy(initialDataModel)
-
+    
     if (query.stan) {
         const stanFileContent = await tryFetch(query.stan)
         if (stanFileContent) {
@@ -105,9 +107,5 @@ export const fetchRemoteAnalysis = async (query: QueryParams) => {
         data.meta.title = query.title
     }
 
-    // TODO(bmw) create a 'setEphemera' helper?
-    data.ephemera.stanFileContent = data.stanFileContent
-    data.ephemera.dataFileContent = data.dataFileContent
-
-    return data
+    return persistStateToEphemera(data);
 }

--- a/gui/src/app/SPAnalysis/SPAnalysisQueryLoading.ts
+++ b/gui/src/app/SPAnalysis/SPAnalysisQueryLoading.ts
@@ -1,0 +1,113 @@
+import { SPAnalysisDataModel, initialDataModel } from "./SPAnalysisDataModel";
+
+
+enum QueryParamKeys {
+    StanFile = "stan",
+    DataFile = "data",
+    SamplingOpts = "sampling_opts",
+    Title = "title",
+    SONumChains = 'num_chains',
+    SONumWarmup = 'num_warmup',
+    SONumSamples = 'num_samples',
+    SOInitRadius = 'init_radius',
+    SOSeed = 'seed'
+}
+
+type QueryParams = {
+    [key in QueryParamKeys]: string | null
+}
+
+export const fromSearchParams = (searchParams: URLSearchParams) => {
+    for (const key of searchParams.keys()) {
+        // warn on unknown keys
+        if (!Object.values(QueryParamKeys).includes(key as QueryParamKeys)) {
+            console.warn('Unknown query parameter', key)
+        }
+    }
+
+    const query: QueryParams = {
+        stan: searchParams.get(QueryParamKeys.StanFile),
+        data: searchParams.get(QueryParamKeys.DataFile),
+        sampling_opts: searchParams.get(QueryParamKeys.SamplingOpts),
+        title: searchParams.get(QueryParamKeys.Title),
+        num_chains: searchParams.get(QueryParamKeys.SONumChains),
+        num_warmup: searchParams.get(QueryParamKeys.SONumWarmup),
+        num_samples: searchParams.get(QueryParamKeys.SONumSamples),
+        init_radius: searchParams.get(QueryParamKeys.SOInitRadius),
+        seed: searchParams.get(QueryParamKeys.SOSeed),
+    }
+    return query
+
+}
+
+const tryFetch = async (url: string) => {
+    console.log('Fetching content from', url)
+    try {
+        const req = await fetch(url)
+        if (!req.ok) {
+            console.error('Failed to fetch from url', url, req.status, req.statusText)
+            return undefined
+        }
+        return await req.text()
+    } catch (err) {
+        console.error('Failed to fetch from url', url, err)
+        return undefined
+    }
+}
+
+const deepCopy = (obj: any) => {
+    return JSON.parse(JSON.stringify(obj))
+}
+
+export const fetchRemoteAnalysis = async (query: QueryParams) => {
+
+    // any special 'project' query could be loaded here at the top
+    const data: SPAnalysisDataModel = deepCopy(initialDataModel)
+
+    if (query.stan) {
+        const stanFileContent = await tryFetch(query.stan)
+        if (stanFileContent) {
+            data.stanFileContent = stanFileContent
+        }
+    }
+    if (query.data) {
+        const dataFileContent = await tryFetch(query.data)
+        if (dataFileContent) {
+            data.dataFileContent = dataFileContent
+        }
+    }
+
+    if (query.sampling_opts) {
+        const text = await tryFetch(query.sampling_opts)
+        if (text) {
+            // TODO(bmw) validate
+            data.samplingOpts = JSON.parse(text)
+        }
+    } else {
+        if (query.num_chains) {
+            data.samplingOpts.num_chains = parseInt(query.num_chains)
+        }
+        if (query.num_warmup) {
+            data.samplingOpts.num_warmup = parseInt(query.num_warmup)
+        }
+        if (query.num_samples) {
+            data.samplingOpts.num_samples = parseInt(query.num_samples)
+        }
+        if (query.init_radius) {
+            data.samplingOpts.init_radius = parseFloat(query.init_radius)
+        }
+        if (query.seed) {
+            data.samplingOpts.seed = parseInt(query.seed)
+        }
+    }
+
+    if (query.title) {
+        data.meta.title = query.title
+    }
+
+    // TODO(bmw) create a 'setEphemera' helper?
+    data.ephemera.stanFileContent = data.stanFileContent
+    data.ephemera.dataFileContent = data.dataFileContent
+
+    return data
+}

--- a/gui/src/app/SPAnalysis/SPAnalysisQueryLoading.ts
+++ b/gui/src/app/SPAnalysis/SPAnalysisQueryLoading.ts
@@ -1,4 +1,6 @@
+import { useSearchParams } from "react-router-dom";
 import { SPAnalysisDataModel, initialDataModel, persistStateToEphemera } from "./SPAnalysisDataModel";
+import { useCallback } from "react";
 
 
 enum QueryParamKeys {
@@ -17,7 +19,17 @@ type QueryParams = {
     [key in QueryParamKeys]: string | null
 }
 
-export const fromSearchParams = (searchParams: URLSearchParams) => {
+export const useQueryParams = () => {
+    const [searchParams, setSearchParams] = useSearchParams();
+
+    const clearSearchParams = useCallback(() => {
+        // whenever the data state is 'dirty', we want to
+        // clear the URL bar as to indiciate that the viewed content is
+        // no longer what the link would point to
+        if (searchParams.size !== 0)
+            setSearchParams(new URLSearchParams())
+    }, [searchParams, setSearchParams]);
+
     for (const key of searchParams.keys()) {
         // warn on unknown keys
         if (!Object.values(QueryParamKeys).includes(key as QueryParamKeys)) {
@@ -25,7 +37,7 @@ export const fromSearchParams = (searchParams: URLSearchParams) => {
         }
     }
 
-    const query: QueryParams = {
+    const queries: QueryParams = {
         stan: searchParams.get(QueryParamKeys.StanFile),
         data: searchParams.get(QueryParamKeys.DataFile),
         sampling_opts: searchParams.get(QueryParamKeys.SamplingOpts),
@@ -36,7 +48,8 @@ export const fromSearchParams = (searchParams: URLSearchParams) => {
         init_radius: searchParams.get(QueryParamKeys.SOInitRadius),
         seed: searchParams.get(QueryParamKeys.SOSeed),
     }
-    return query
+
+    return { queries, clearSearchParams }
 }
 
 export const queryStringHasParameters = (query: QueryParams) => {

--- a/gui/src/app/SPAnalysis/SPAnalysisReducer.ts
+++ b/gui/src/app/SPAnalysis/SPAnalysisReducer.ts
@@ -34,7 +34,14 @@ export type SPAnalysisReducerAction = {
     type: 'clear'
 }
 
-export const SPAnalysisReducer: SPAnalysisReducerType = (s: SPAnalysisDataModel, a: SPAnalysisReducerAction) => {
+export const SPAnalysisReducer = (onDirty: () => void) => (s: SPAnalysisDataModel, a: SPAnalysisReducerAction) => {
+    if (a.type !== "loadInitialData") {
+        // TextEditor seems to trigger occasional spurious edits where nothing changes
+        if (a.type !== "editFile" || s[a.filename] != a.content) {
+            onDirty();
+        }
+    }
+
     switch (a.type) {
         case "loadStanie": {
             const dataFileContent = JSON.stringify(a.stanie.data, null, 2);

--- a/gui/src/app/SPAnalysis/SPAnalysisReducer.ts
+++ b/gui/src/app/SPAnalysis/SPAnalysisReducer.ts
@@ -28,7 +28,7 @@ export type SPAnalysisReducerAction = {
     type: 'setSamplingOpts',
     opts: Partial<SamplingOpts>
 } | {
-    type: 'loadLocalStorage',
+    type: 'loadInitialData',
     state: SPAnalysisDataModel
 } | {
     type: 'clear'
@@ -71,9 +71,9 @@ export const SPAnalysisReducer: SPAnalysisReducerType = (s: SPAnalysisDataModel,
             return newState
         }
         case "setSamplingOpts": {
-            return { ...s, samplingOpts: { ...s.samplingOpts, ...a.opts }}
+            return { ...s, samplingOpts: { ...s.samplingOpts, ...a.opts } }
         }
-        case "loadLocalStorage": {
+        case "loadInitialData": {
             return a.state;
         }
         case "clear": {


### PR DESCRIPTION
This is my combination of #65 and #39 on top of the new data model and react-router-dom's useSearchParams.

Jeremy's example link of 

http://127.0.0.1:3000/?stan=https://gist.githubusercontent.com/magland/da3d4143276827609ec9317bb3db8b04/raw/cf48846a36de0559f96a9e4bcb5a5dcbe46383be/main.stan&data=https://gist.githubusercontent.com/magland/da3d4143276827609ec9317bb3db8b04/raw/cf48846a36de0559f96a9e4bcb5a5dcbe46383be/data.json&num_chains=6&num_warmup=1000&num_samples=1000&init_radius=2&seed=6&title=test_title

still works in this PR. 

This is the first part of #50 


Wishlist:
1. This added a lot of code to the ContextProvider which may be better put elsewhere
2. I noted a few places where utility functions may be useful, but some I think already exist in other PRs (I already took @jsoules' `modelHasUnsavedChanges`