### PR TITLE
collapsible side panel

### DIFF
--- a/gui/src/app/SPAnalysis/SPAnalysisContextProvider.tsx
+++ b/gui/src/app/SPAnalysis/SPAnalysisContextProvider.tsx
@@ -41,7 +41,9 @@ const SPAnalysisContextProvider: FunctionComponent<PropsWithChildren<SPAnalysisC
         const savedState = localStorage.getItem('stan-playground-saved-state')
         if (!savedState) return
         const parsedData = deserializeAnalysisFromLocalStorage(savedState)
-        update({ type: 'loadLocalStorage', state: parsedData })
+        if (parsedData) {
+            update({ type: 'loadLocalStorage', state: parsedData })
+        }
     }, [])
     ////////////////////////////////////////////////////////////////////////////////////////
 

--- a/gui/src/app/pages/HomePage/HomePage.tsx
+++ b/gui/src/app/pages/HomePage/HomePage.tsx
@@ -121,7 +121,7 @@ const HomePageChild: FunctionComponent<Props> = ({ width, height }) => {
 // the width of the left panel when it is expanded based on the overall width
 const determineLeftPanelWidth = (width: number) => {
     const minWidth = 250
-    const maxWidth = 500
+    const maxWidth = 400
     return Math.min(maxWidth, Math.max(minWidth, width / 4))
 }
 

--- a/gui/src/app/pages/HomePage/HomePage.tsx
+++ b/gui/src/app/pages/HomePage/HomePage.tsx
@@ -45,15 +45,12 @@ const HomePageChild: FunctionComponent<Props> = ({ width, height }) => {
     // too small but we only want to do this right when we cross the threshold,
     // not every time we resize by a pixel. Similar for expanding the panel when
     // we cross the threshold in the other direction.
-    const lastWidth = useRef(width)
+    const lastShouldBeCollapsed = useRef(determineShouldBeInitiallyCollapsed(width))
     useEffect(() => {
-        if (!determineShouldBeInitiallyCollapsed(lastWidth.current) && determineShouldBeInitiallyCollapsed(width)) {
-            lastWidth.current = width
-            setLeftPanelCollapsed(true)
-        }
-        else if (determineShouldBeInitiallyCollapsed(lastWidth.current) && !determineShouldBeInitiallyCollapsed(width)) {
-            lastWidth.current = width
-            setLeftPanelCollapsed(false)
+        const shouldBeCollapsed = determineShouldBeInitiallyCollapsed(width)
+        if (shouldBeCollapsed !== lastShouldBeCollapsed.current) {
+            lastShouldBeCollapsed.current = shouldBeCollapsed
+            setLeftPanelCollapsed(shouldBeCollapsed)
         }
     }, [width])
 

--- a/gui/src/app/pages/HomePage/LeftPanel.tsx
+++ b/gui/src/app/pages/HomePage/LeftPanel.tsx
@@ -1,18 +1,21 @@
-import { Hyperlink } from "@fi-sci/misc"
+import { Hyperlink, SmallIconButton } from "@fi-sci/misc"
 import ModalWindow, { useModalWindow } from "@fi-sci/modal-window"
 import { FunctionComponent, useCallback, useContext } from "react"
 import examplesStanies, { Stanie } from "../../exampleStanies/exampleStanies"
 import { SPAnalysisContext } from "../../SPAnalysis/SPAnalysisContextProvider"
 import ExportWindow from "./ExportWindow"
 import ImportWindow from "./ImportWindow"
+import { ChevronLeft, ChevronRight } from "@mui/icons-material"
 
 type LeftPanelProps = {
     width: number
     height: number
     hasUnsavedChanges: boolean
+    collapsed: boolean
+    onSetCollapsed: (collapsed: boolean) => void
 }
 
-const LeftPanel: FunctionComponent<LeftPanelProps> = ({ width, height, hasUnsavedChanges }) => {
+const LeftPanel: FunctionComponent<LeftPanelProps> = ({ width, height, hasUnsavedChanges, collapsed, onSetCollapsed }) => {
     // note: this is close enough to pass in directly if we wish
     const { update } = useContext(SPAnalysisContext)
 
@@ -22,9 +25,21 @@ const LeftPanel: FunctionComponent<LeftPanelProps> = ({ width, height, hasUnsave
 
     const { visible: exportVisible, handleOpen: exportOpen, handleClose: exportClose } = useModalWindow()
     const { visible: importVisible, handleOpen: importOpen, handleClose: importClose } = useModalWindow()
+
+    if (collapsed) {
+        return (
+            <div style={{position: 'absolute', width, height, backgroundColor: 'lightgray', overflowY: 'auto'}}>
+                <div style={{margin: 5}}>
+                    <ExpandButton onClick={() => onSetCollapsed(false)} />
+                </div>
+            </div>
+        )
+    }
+
     return (
         <div style={{position: 'absolute', width, height, backgroundColor: 'lightgray', overflowY: 'auto'}}>
             <div style={{margin: 5}}>
+                <CollapseButton onClick={() => onSetCollapsed(true)} />
                 <h3>Examples</h3>
                 {
                     examplesStanies.map((stanie, i) => (
@@ -82,6 +97,26 @@ const LeftPanel: FunctionComponent<LeftPanelProps> = ({ width, height, hasUnsave
                 />
             </ModalWindow>
         </div>
+    )
+}
+
+const ExpandButton: FunctionComponent<{ onClick: () => void }> = ({ onClick }) => {
+    return (
+        <SmallIconButton
+            icon={<ChevronRight />}
+            onClick={onClick}
+            title="Expand"
+        />
+    )
+}
+
+const CollapseButton: FunctionComponent<{ onClick: () => void }> = ({ onClick }) => {
+    return (
+        <SmallIconButton
+            icon={<ChevronLeft />}
+            onClick={onClick}
+            title="Collapse"
+        />
     )
 }
 


### PR DESCRIPTION
Addresses #86 

Implement collapsible/expandable left panel.

Upon initial load, determines if width is too small (like on a device) and defaults to a collapsed panel.

When panel is collapsed there's a chevron button you can press or click to expand.

When expanded, width is determined based on overall width based on a formula.

When expanded, there's a chevron button you can press or click to collapse.

AND advanced: when resizing a browser window and you transition from large-enough to too-small the panel automatically collapses. Similarly when you transition from too-small to large-enough the panel automatically expands.

This is the functionality that I felt was most natural.