### PR TITLE
Enable back button functionality, clear url on load

### DIFF
--- a/gui/src/app/SPAnalysis/SPAnalysisContextProvider.tsx
+++ b/gui/src/app/SPAnalysis/SPAnalysisContextProvider.tsx
@@ -24,7 +24,6 @@ const SPAnalysisContextProvider: FunctionComponent<PropsWithChildren<SPAnalysisC
 
     const [searchParams, setSearchParams] = useSearchParams();
 
-
     useEffect(() => {
         // as user reloads the page or closes the tab, save state to local storage
         const handleBeforeUnload = () => {
@@ -39,8 +38,6 @@ const SPAnalysisContextProvider: FunctionComponent<PropsWithChildren<SPAnalysisC
     }, [data])
 
     useEffect(() => {
-        if (searchParams.size === 0 && data !== initialDataModel) return;
-
         const queries = fromQueryParams(searchParams)
         if (queryStringHasParameters(queries)) {
             fetchRemoteAnalysis(queries).then((data) => {
@@ -58,8 +55,10 @@ const SPAnalysisContextProvider: FunctionComponent<PropsWithChildren<SPAnalysisC
             const parsedData = deserializeAnalysisFromLocalStorage(savedState)
             update({ type: 'loadInitialData', state: parsedData })
         }
-
-    }, [data, searchParams, setSearchParams])
+        // once we have loaded some data, we don't need the localStorage again
+        // and it will be overwritten by the above event listener on close
+        localStorage.removeItem('stan-playground-saved-state')
+    }, [searchParams, setSearchParams])
 
     return (
         <SPAnalysisContext.Provider value={{ data, update }}>

--- a/gui/src/app/SPAnalysis/SPAnalysisQueryLoading.ts
+++ b/gui/src/app/SPAnalysis/SPAnalysisQueryLoading.ts
@@ -1,6 +1,4 @@
-import { useSearchParams } from "react-router-dom";
 import { SPAnalysisDataModel, initialDataModel, persistStateToEphemera } from "./SPAnalysisDataModel";
-import { useCallback } from "react";
 
 
 enum QueryParamKeys {
@@ -19,16 +17,7 @@ type QueryParams = {
     [key in QueryParamKeys]: string | null
 }
 
-export const useQueryParams = () => {
-    const [searchParams, setSearchParams] = useSearchParams();
-
-    const clearSearchParams = useCallback(() => {
-        // whenever the data state is 'dirty', we want to
-        // clear the URL bar as to indiciate that the viewed content is
-        // no longer what the link would point to
-        if (searchParams.size !== 0)
-            setSearchParams(new URLSearchParams())
-    }, [searchParams, setSearchParams]);
+export const fromQueryParams = (searchParams: URLSearchParams) => {
 
     for (const key of searchParams.keys()) {
         // warn on unknown keys
@@ -49,7 +38,7 @@ export const useQueryParams = () => {
         seed: searchParams.get(QueryParamKeys.SOSeed),
     }
 
-    return { queries, clearSearchParams }
+    return queries;
 }
 
 export const queryStringHasParameters = (query: QueryParams) => {

--- a/gui/src/app/SPAnalysis/SPAnalysisReducer.ts
+++ b/gui/src/app/SPAnalysis/SPAnalysisReducer.ts
@@ -34,14 +34,7 @@ export type SPAnalysisReducerAction = {
     type: 'clear'
 }
 
-export const SPAnalysisReducer = (onDirty: () => void) => (s: SPAnalysisDataModel, a: SPAnalysisReducerAction) => {
-    if (a.type !== "loadInitialData") {
-        // TextEditor seems to trigger occasional spurious edits where nothing changes
-        if (a.type !== "editFile" || s[a.filename] != a.content) {
-            onDirty();
-        }
-    }
-
+export const SPAnalysisReducer = (s: SPAnalysisDataModel, a: SPAnalysisReducerAction) => {
     switch (a.type) {
         case "loadStanie": {
             const dataFileContent = JSON.stringify(a.stanie.data, null, 2);


### PR DESCRIPTION
See discussion before merge in #84

This makes two changes:

1. Query parameters are cleared on load, rather than on first edit. This "godbolt.org style" is my preference in the design space, but it also technically made item 2 much easier:
2. Clicking the back button into a history item with the query parameters present leads to them actually loading in the UI


This also made it so the reducer no longer needs a callback to clear the URL on edit, since it will be done during load. 
