### PR TITLE
type guards for SPAnalysisDataModel

### DIFF
--- a/gui/src/app/SPAnalysis/SPAnalysisContextProvider.tsx
+++ b/gui/src/app/SPAnalysis/SPAnalysisContextProvider.tsx
@@ -9,6 +9,7 @@ type SPAnalysisContextType = {
 }
 
 type SPAnalysisContextProviderProps = {
+    //
 }
 
 export const SPAnalysisContext = createContext<SPAnalysisContextType>({
@@ -41,6 +42,7 @@ const SPAnalysisContextProvider: FunctionComponent<PropsWithChildren<SPAnalysisC
         const savedState = localStorage.getItem('stan-playground-saved-state')
         if (!savedState) return
         const parsedData = deserializeAnalysisFromLocalStorage(savedState)
+        if (!parsedData) return // unsuccessful parse or type cast
         update({ type: 'loadLocalStorage', state: parsedData })
     }, [])
     ////////////////////////////////////////////////////////////////////////////////////////

--- a/gui/src/app/SPAnalysis/SPAnalysisDataModel.ts
+++ b/gui/src/app/SPAnalysis/SPAnalysisDataModel.ts
@@ -27,6 +27,7 @@ const isSPAnalysisBase = (x: any): x is SPAnalysisBase => {
     if (!x) return false
     if (typeof x !== 'object') return false
     if (!isSamplingOpts(x.samplingOpts)) return false
+    if (!isSPAnalysisFiles(x)) return false
     return true
 }
 

--- a/gui/src/app/SPAnalysis/SPAnalysisDataModel.ts
+++ b/gui/src/app/SPAnalysis/SPAnalysisDataModel.ts
@@ -1,4 +1,4 @@
-import { SamplingOpts, defaultSamplingOpts } from "../StanSampler/StanSampler"
+import { SamplingOpts, defaultSamplingOpts, isSamplingOpts } from "../StanSampler/StanSampler"
 
 export enum SPAnalysisKnownFiles {
     STANFILE = 'stanFileContent',
@@ -9,13 +9,36 @@ type SPAnalysisFiles = {
     [filetype in SPAnalysisKnownFiles]: string
 }
 
+const isSPAnalysisFiles = (x: any): x is SPAnalysisFiles => {
+    if (!x) return false
+    if (typeof x !== 'object') return false
+    for (const k of Object.values(SPAnalysisKnownFiles)) {
+        if (typeof x[k] !== 'string') return false
+    }
+    return true
+}
+
 type SPAnalysisBase = SPAnalysisFiles &
 {
     samplingOpts: SamplingOpts
 }
 
+const isSPAnalysisBase = (x: any): x is SPAnalysisBase => {
+    if (!x) return false
+    if (typeof x !== 'object') return false
+    if (!isSamplingOpts(x.samplingOpts)) return false
+    return true
+}
+
 type SPAnalysisMetadata = {
     title: string
+}
+
+export const isSPAnalysisMetaData = (x: any): x is SPAnalysisMetadata => {
+    if (!x) return false
+    if (typeof x !== 'object') return false
+    if (typeof x.title !== 'string') return false
+    return true
 }
 
 type SPAnalysisEphemeralData = SPAnalysisFiles & {
@@ -25,11 +48,26 @@ type SPAnalysisEphemeralData = SPAnalysisFiles & {
     server?: string
 }
 
+const isSPAnalysisEphemeralData = (x: any): x is SPAnalysisEphemeralData => {
+    if (!isSPAnalysisFiles(x)) return false
+    return true
+}
+
 export type SPAnalysisDataModel = SPAnalysisBase &
 {
     meta: SPAnalysisMetadata,
     ephemera: SPAnalysisEphemeralData
 }
+
+export const isSPAnalysisDataModel = (x: any): x is SPAnalysisDataModel => {
+    if (!x) return false
+    if (typeof x !== 'object') return false
+    if (!isSPAnalysisMetaData(x.meta)) return false
+    if (!isSPAnalysisEphemeralData(x.ephemera)) return false
+    if (!isSPAnalysisBase(x)) return false
+    return true
+}
+
 
 export type SPAnalysisPersistentDataModel = Omit<SPAnalysisDataModel, "ephemera">
 

--- a/gui/src/app/SPAnalysis/SPAnalysisQueryLoading.ts
+++ b/gui/src/app/SPAnalysis/SPAnalysisQueryLoading.ts
@@ -1,6 +1,7 @@
 import { useSearchParams } from "react-router-dom";
 import { SPAnalysisDataModel, initialDataModel, persistStateToEphemera } from "./SPAnalysisDataModel";
 import { useCallback } from "react";
+import { isSamplingOpts } from "../StanSampler/StanSampler";
 
 
 enum QueryParamKeys {
@@ -96,8 +97,12 @@ export const fetchRemoteAnalysis = async (query: QueryParams) => {
     if (sampling_opts) {
         try {
             const parsed = JSON.parse(sampling_opts)
-            // TODO validate the parsed object
-            data.samplingOpts = parsed
+            if (isSamplingOpts(parsed)) {
+                data.samplingOpts = parsed
+            }
+            else {
+                console.error('Invalid sampling_opts in fetchRemoteAnalysis', parsed)
+            }
         } catch (err) {
             console.error('Failed to parse sampling_opts', err)
         }

--- a/gui/src/app/SPAnalysis/SPAnalysisReducer.ts
+++ b/gui/src/app/SPAnalysis/SPAnalysisReducer.ts
@@ -1,8 +1,8 @@
 import { Reducer } from "react"
 import { Stanie } from "../exampleStanies/exampleStanies"
-import { defaultSamplingOpts, SamplingOpts } from '../StanSampler/StanSampler'
+import { defaultSamplingOpts, isSamplingOpts, SamplingOpts } from '../StanSampler/StanSampler'
 import { FieldsContentsMap } from "./FileMapping"
-import { initialDataModel, persistStateToEphemera, SPAnalysisDataModel, SPAnalysisKnownFiles } from "./SPAnalysisDataModel"
+import { initialDataModel, isSPAnalysisMetaData, persistStateToEphemera, SPAnalysisDataModel, SPAnalysisKnownFiles } from "./SPAnalysisDataModel"
 
 
 export type SPAnalysisReducerType = Reducer<SPAnalysisDataModel, SPAnalysisReducerAction>
@@ -52,7 +52,14 @@ export const SPAnalysisReducer: SPAnalysisReducerType = (s: SPAnalysisDataModel,
             }
         }
         case "loadFiles": {
-            return loadFromProjectFiles(s, a.files, a.clearExisting)
+            try {
+                return loadFromProjectFiles(s, a.files, a.clearExisting)
+            }
+            catch (e) {
+                // probably sampling opts or meta files were not valid
+                console.error('Error loading files', e)
+                return s
+            }
         }
         case "retitle": {
             return {
@@ -84,14 +91,18 @@ export const SPAnalysisReducer: SPAnalysisReducerType = (s: SPAnalysisDataModel,
 
 const loadMetaFromString = (data: SPAnalysisDataModel, json: string, clearExisting: boolean = false): SPAnalysisDataModel => {
     const newMeta = JSON.parse(json)
-    // TODO: properly check type of deserialized meta
+    if (!isSPAnalysisMetaData(newMeta)) {
+        throw Error('Deserialized meta is not valid')
+    }
     const newMetaMember = clearExisting ? { ...newMeta } : { ...data.meta, ...newMeta }
     return { ...data, meta: newMetaMember }
 }
 
 const loadSamplingOptsFromString = (data: SPAnalysisDataModel, json: string, clearExisting: boolean = false): SPAnalysisDataModel => {
     const newSampling = JSON.parse(json)
-    // TODO: properly check type/fields of deserialized sampling opts
+    if (!isSamplingOpts(newSampling)) {
+        throw Error('Deserialized sampling opts are not valid')
+    }
     const newSamplingOptsMember = clearExisting ? { ...newSampling } : { ...data.samplingOpts, ...newSampling }
     return { ...data, samplingOpts: newSamplingOptsMember }
 }

--- a/gui/src/app/StanSampler/StanSampler.ts
+++ b/gui/src/app/StanSampler/StanSampler.ts
@@ -12,6 +12,17 @@ export type SamplingOpts = {
     seed: number | undefined
 }
 
+export const isSamplingOpts = (x: any): x is SamplingOpts => {
+    if (!x) return false
+    if (typeof x !== 'object') return false
+    if (typeof x.num_chains !== 'number') return false
+    if (typeof x.num_warmup !== 'number') return false
+    if (typeof x.num_samples !== 'number') return false
+    if (typeof x.init_radius !== 'number') return false
+    if (x.seed !== undefined && typeof x.seed !== 'number') return false
+    return true
+}
+
 export const defaultSamplingOpts: SamplingOpts = {
     num_chains: 4,
     num_warmup: 1000,


### PR DESCRIPTION
Fixes #89 

Added some type guards which are used to check the input of local storage and also in `loadFromProjectFiles`

This was somewhat difficult to test because if you manually put an error in the local storage, that gets overwritten upon page reload. So I managed to achieve this test by putting a temporary error in the write-to-local-storage code and verified that the page did not crash and I got the warning message upon reload.