### PR TITLE
[WIP] Export project to Gist

### DIFF
--- a/gui/src/app/pages/HomePage/ExportWindow.tsx
+++ b/gui/src/app/pages/HomePage/ExportWindow.tsx
@@ -1,9 +1,10 @@
-import { FunctionComponent, useContext } from "react"
+import { FunctionComponent, useCallback, useContext, useState } from "react"
 
-import { mapModelToFileManifest } from "../../SPAnalysis/FileMapping"
+import { FileRegistry, mapModelToFileManifest } from "../../SPAnalysis/FileMapping"
 import { SPAnalysisContext } from "../../SPAnalysis/SPAnalysisContextProvider"
 import { serializeAsZip } from "../../SPAnalysis/SPAnalysisSerialization"
 import { triggerDownload } from "../../util/triggerDownload"
+import saveAsGitHubGist from "./saveAsGitHubGist"
 
 type ExportWindowProps = {
     onClose: () => void
@@ -13,10 +14,12 @@ const ExportWindow: FunctionComponent<ExportWindowProps> = ({ onClose }) => {
     const { data, update } = useContext(SPAnalysisContext)
     const fileManifest = mapModelToFileManifest(data)
 
+    const [exportingToGist, setExportingToGist] = useState(false)
+
     return (
         <div>
             <h3>Export this analysis</h3>
-            <table className="table1">
+            <table className="table1" style={{maxWidth: 500}}>
                 <tbody>
                     <tr>
                         <td>Title</td>
@@ -39,13 +42,27 @@ const ExportWindow: FunctionComponent<ExportWindowProps> = ({ onClose }) => {
                     }
                 </tbody>
             </table>
-            <div>
-                <button onClick={async () => {
-                    serializeAsZip(data).then(([zipBlob, name]) => triggerDownload(zipBlob, `SP-${name}.zip`, onClose))
-                }}>
-                    Export to .zip file
-                </button>
-            </div>
+            <div>&nbsp;</div>
+            {!exportingToGist && (
+                <div>
+                    <button onClick={async () => {
+                        serializeAsZip(data).then(([zipBlob, name]) => triggerDownload(zipBlob, `SP-${name}.zip`, onClose))
+                    }}>
+                        Export to .zip file
+                    </button>
+                    &nbsp;
+                    <button onClick={() => {setExportingToGist(true)}}>
+                        Export to GitHub Gist
+                    </button>
+                </div>
+            )}
+            {exportingToGist && (
+                <GistExportView
+                    fileManifest={fileManifest}
+                    title={data.meta.title}
+                    onClose={onClose}
+                />
+            )}
         </div>
     )
 }
@@ -64,6 +81,94 @@ const EditTitleComponent: FunctionComponent<EditTitleComponentProps> = ({ value,
             onChange={e => onChange(e.target.value)}
         />
     )
+}
+
+type GistExportViewProps = {
+    fileManifest: Partial<FileRegistry>
+    title: string
+    onClose: () => void
+}
+
+const GistExportView: FunctionComponent<GistExportViewProps> = ({ fileManifest, title, onClose }) => {
+    const [gitHubPersonalAccessToken, setGitHubPersonalAccessToken] = useState('')
+    const [gistUrl, setGistUrl] = useState<string | null>(null)
+
+    const handleExport = useCallback(async () => {
+        try {
+            const gistUrl = await saveAsGitHubGist(fileManifest, {defaultDescription: title, personalAccessToken: gitHubPersonalAccessToken})
+            setGistUrl(gistUrl)
+        }
+        catch (err: any) {
+            alert(`Error exporting to GitHub Gist: ${err.message}`)
+        }
+    }, [gitHubPersonalAccessToken, fileManifest, title])
+
+    return (
+        <div style={{maxWidth: 800}}>
+            <h3>Export to GitHub Gist</h3>
+            <p>
+                In order to save this project as a GitHub Gist, you will need to provide a GitHub Personal Access Token.&nbsp;
+                This token will be used to authenticate with GitHub and create a new Gist with the files in this project.&nbsp;
+                You can create a new Personal Access Token by visiting your <a href="https://github.com/settings" target="_blank" rel="noreferrer">GitHub settings</a>.&nbsp;
+                Go to <i>Developer settings</i> and <i>Tokens (classic)</i>.&nbsp;
+                Generate a new classic token and be sure to only grant gist scope with an expiration date.&nbsp;
+                Copy the token and paste it into the field below.
+            </p>
+            <p>
+                For security reasons, your token will not be saved in this application,&nbsp;
+                so you may want to store it securely in a text file for future use.
+            </p>
+            <table className="table1" style={{maxWidth: 500}}>
+                <tbody>
+                    <tr>
+                        <td>GitHub Personal Access Token</td>
+                        <td>
+                            <input
+                                type="password"
+                                value={gitHubPersonalAccessToken}
+                                onChange={e => setGitHubPersonalAccessToken(e.target.value)}
+                            />
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <div>&nbsp;</div>
+            {!gistUrl && (
+                <div>
+                    <button onClick={handleExport} disabled={!gitHubPersonalAccessToken}>
+                        Export to GitHub Gist
+                    </button>
+                    &nbsp;
+                    <button onClick={onClose}>
+                        Cancel
+                    </button>
+                </div>
+            )}
+            {gistUrl && (
+                <div>
+                    <p>
+                        Successfully exported to GitHub Gist:&nbsp;
+                        <a href={gistUrl} target="_blank" rel="noreferrer">{gistUrl}</a>
+                    </p>
+                    <p>
+                        You can now share the following link to this Stan Playground project:&nbsp;<br /><br />
+                        <a href={makeSPShareableLinkFromGistUrl(gistUrl)} target="_blank" rel="noreferrer">{makeSPShareableLinkFromGistUrl(gistUrl)}</a>
+                        <br />
+                    </p>
+                    <button onClick={onClose}>
+                        Close
+                    </button>
+                </div>
+            )}
+        </div>
+    )
+}
+
+const makeSPShareableLinkFromGistUrl = (gistUrl: string) => {
+    const protocol = window.location.protocol
+    const host = window.location.host
+    const url = `${protocol}//${host}?project=${gistUrl}`
+    return url
 }
 
 export default ExportWindow

--- a/gui/src/app/pages/HomePage/saveAsGitHubGist.ts
+++ b/gui/src/app/pages/HomePage/saveAsGitHubGist.ts
@@ -1,0 +1,78 @@
+import {Octokit} from '@octokit/core';
+
+const saveAsGitHubGist = async (files: {[key: string]: string}, o: {defaultDescription: string, personalAccessToken: string}) => {
+    const {defaultDescription, personalAccessToken} = o;
+    const description = prompt("SAVING AS PUBLIC GIST: Enter a description:", defaultDescription);
+    if (!description) {
+        throw Error('No description provided');
+    }
+    const octokit = new Octokit({
+        auth: personalAccessToken
+    });
+    const files2: {[key: string]: {content: string}} = {};
+    for (const key in files) {
+        const key2 = replaceSlashesWithBars(key);
+        let content2 = files[key];
+        // gists do not support empty files or whitespace-only files
+        if (content2.trim() === '') {
+            content2 = '<<empty>>' + content2; // include the whitespace so we can recover the original file
+        }
+        files2[key2] = {content: content2};
+    }
+    const r = await octokit.request('POST /gists', {
+        description,
+        'public': true,
+        files: files2,
+        headers: {
+            'X-GitHub-Api-Version': '2022-11-28'
+        }
+    });
+    // const gistId = r.data.id;
+    const gistUrl = r.data.html_url;
+    if (!gistUrl) {
+        throw new Error('Problem creating gist. r.data.html_url is null.');
+    }
+    return gistUrl;
+}
+
+export const updateGitHubGist = async (gistUri: string, patch: {[path: string]: string | null}) => {
+    const token = prompt("UPDATING GIST: Enter your GitHub personal access token (this is not stored). The token must permit creating gists.");
+    if (!token) {
+        return;
+    }
+    const octokit = new Octokit({
+        auth: token
+    });
+    const gistId = gistUri.split('/').pop();
+    if (!gistId) {
+        throw new Error('Invalid gist URI');
+    }
+    // patch
+    const files: {[key: string]: {content?: string}} = {};
+    for (const path in patch) {
+        const path2 = replaceSlashesWithBars(path);
+        let content = patch[path];
+        if (content === null) {
+            files[path2] = {};
+        }
+        else {
+            if (content.trim() === '') {
+                content = '<<empty>>' + content; // include the whitespace so we can recover the original file
+            }
+            files[path2] = {content};
+        }
+    }
+    await octokit.request(`PATCH /gists/${gistId}`, {
+        gist_id: gistId,
+        files,
+        headers: {
+            'X-GitHub-Api-Version': '2022-11-28'
+        }
+    });
+}
+
+const replaceSlashesWithBars = (s: string) => {
+    return s.split('/').join('|');
+}
+
+export default saveAsGitHubGist;


### PR DESCRIPTION
Adds functionality for saving a project to Gist. This includes #97 content, so that should get merged first.

To try it out, click on "Export" and then there's a button "Export to GitHub Gist". It will walk you through the steps and provide instructions on providing an access token with proper scope.

In a separate PR we can figure out what to do about updating an existing gist.

To summarize:
* Export
* Export to GitHub Gist
* Read instructions on getting the PAT
* Enter the PAT
* Click "Export to GitHub Gist"
* Retrieve the url to the gist AND the shareable SP url that loads the gist