### PR TITLE
rearrange main layout

### DIFF
--- a/gui/src/app/SPAnalysis/SPAnalysisDataModel.ts
+++ b/gui/src/app/SPAnalysis/SPAnalysisDataModel.ts
@@ -60,6 +60,10 @@ export const modelHasUnsavedChanges = (data: SPAnalysisDataModel): boolean => {
     return stringFileKeys.some((k) => data[k] !== data.ephemera[k])
 }
 
+export const modelHasUnsavedDataFileChanges = (data: SPAnalysisDataModel): boolean => {
+    return data.dataFileContent !== data.ephemera.dataFileContent
+}
+
 export const stringifyField = (data: SPAnalysisDataModel, field: keyof SPAnalysisDataModel): string => {
     if (field === 'ephemera') return ''
     const value = data[field]

--- a/gui/src/app/SamplingOptsPanel/SamplingOptsPanel.tsx
+++ b/gui/src/app/SamplingOptsPanel/SamplingOptsPanel.tsx
@@ -32,7 +32,7 @@ const SamplingOptsPanel: FunctionComponent<SamplingOptsPanelProps> = ({ sampling
         setSamplingOpts && setSamplingOpts(defaultSamplingOpts)
     }, [setSamplingOpts])
     return (
-        <div>
+        <div style={{padding: 10}}>
             <Grid container spacing={sp1}>
                 <Grid container item xs={12} spacing={sp2} title="Number of sampling chains">
                     <Grid item xs={6}>

--- a/gui/src/app/pages/HomePage/HomePage.tsx
+++ b/gui/src/app/pages/HomePage/HomePage.tsx
@@ -159,22 +159,6 @@ type RightViewProps = {
 }
 
 const RightView: FunctionComponent<RightViewProps> = ({ width, height, compiledMainJsUrl }) => {
-    return (
-        <LowerRightView
-            width={width}
-            height={height}
-            compiledMainJsUrl={compiledMainJsUrl}
-        />
-    )
-}
-
-type LowerRightViewProps = {
-    width: number
-    height: number
-    compiledMainJsUrl?: string
-}
-
-const LowerRightView: FunctionComponent<LowerRightViewProps> = ({ width, height, compiledMainJsUrl }) => {
     const { data, update } = useContext(SPAnalysisContext)
     const dataIsSaved = data.dataFileContent === data.ephemera.dataFileContent
     const parsedData = useMemo(() => {

--- a/gui/src/app/pages/HomePage/HomePage.tsx
+++ b/gui/src/app/pages/HomePage/HomePage.tsx
@@ -6,7 +6,7 @@ import RunPanel from "../../RunPanel/RunPanel";
 import SamplerOutputView from "../../SamplerOutputView/SamplerOutputView";
 import SamplingOptsPanel from "../../SamplingOptsPanel/SamplingOptsPanel";
 import SPAnalysisContextProvider, { SPAnalysisContext } from '../../SPAnalysis/SPAnalysisContextProvider';
-import { modelHasUnsavedChanges, SPAnalysisKnownFiles } from "../../SPAnalysis/SPAnalysisDataModel";
+import { modelHasUnsavedChanges, modelHasUnsavedDataFileChanges, SPAnalysisKnownFiles } from "../../SPAnalysis/SPAnalysisDataModel";
 import { SamplingOpts } from "../../StanSampler/StanSampler";
 import useStanSampler, { useSamplerStatus } from "../../StanSampler/useStanSampler";
 import LeftPanel from "./LeftPanel";
@@ -160,7 +160,6 @@ type RightViewProps = {
 
 const RightView: FunctionComponent<RightViewProps> = ({ width, height, compiledMainJsUrl }) => {
     const { data, update } = useContext(SPAnalysisContext)
-    const dataIsSaved = data.dataFileContent === data.ephemera.dataFileContent
     const parsedData = useMemo(() => {
         try {
             return JSON.parse(data.dataFileContent)
@@ -193,7 +192,7 @@ const RightView: FunctionComponent<RightViewProps> = ({ width, height, compiledM
                     height={samplingOptsPanelHeight}
                     sampler={sampler}
                     data={parsedData}
-                    dataIsSaved={dataIsSaved}
+                    dataIsSaved={!modelHasUnsavedDataFileChanges(data)}
                     samplingOpts={data.samplingOpts}
                 />
             </div>

--- a/gui/src/app/pages/HomePage/LeftPanel.tsx
+++ b/gui/src/app/pages/HomePage/LeftPanel.tsx
@@ -59,11 +59,7 @@ const LeftPanel: FunctionComponent<LeftPanelProps> = ({ width, height, hasUnsave
                         update({ type: 'clear' })
                     }}>Clear all</button>
                 </div>
-                <div>
-                    <p>
-                        This panel will have controls for loading/saving data from cloud
-                    </p>
-                </div>
+                <div>&nbsp;</div>
                 <div>
                     <button
                         onClick={importOpen}


### PR DESCRIPTION
Moved data editor to left panel, underneath the stan editor, to make more room for the sampling controls and sampling output panel on the right. Made some other minor adjustments of spacing and sizing. Simplified the data flow in the HomePage. Replaces #45

![image](https://github.com/flatironinstitute/stan-playground/assets/3679296/c3bbf9ae-eb5d-4594-95e7-553fce7f4c76)
