### PR TITLE
minor: Remove unnecessary text param in onSave functions

### DIFF
--- a/gui/src/app/FileEditor/DataFileEditor.tsx
+++ b/gui/src/app/FileEditor/DataFileEditor.tsx
@@ -5,7 +5,7 @@ import TextEditor, { ToolbarItem } from "./TextEditor";
 type Props = {
     fileName: string
     fileContent: string
-    onSaveContent: (text: string) => void
+    onSaveContent: () => void
     editedFileContent: string
     setEditedFileContent: (text: string) => void
     onDeleteFile?: () => void

--- a/gui/src/app/FileEditor/StanFileEditor.tsx
+++ b/gui/src/app/FileEditor/StanFileEditor.tsx
@@ -10,7 +10,7 @@ import { StancErrors } from '../Stanc/Types';
 type Props = {
     fileName: string
     fileContent: string
-    onSaveContent: (text: string) => void
+    onSaveContent: () => void
     editedFileContent: string
     setEditedFileContent: (text: string) => void
     onDeleteFile?: () => void

--- a/gui/src/app/FileEditor/TextEditor.tsx
+++ b/gui/src/app/FileEditor/TextEditor.tsx
@@ -22,7 +22,7 @@ export type CodeMarker = {
 type Props = {
     defaultText?: string
     text: string | undefined
-    onSaveText: (text: string) => void
+    onSaveText: () => void
     editedText?: string
     onSetEditedText: (text: string) => void
     language: string
@@ -54,8 +54,8 @@ const TextEditor: FunctionComponent<Props> = ({defaultText, text, onSaveText, ed
         onSetEditedText(value || '')
     }, [onSetEditedText])
     const handleSave = useCallback(() => {
-        onSaveText(editedText || '')
-    }, [editedText, onSaveText])
+        onSaveText()
+    }, [onSaveText])
 
     //////////////////////////////////////////////////
     // Seems that it is important to set the initial value of the editor

--- a/gui/src/app/pages/HomePage/HomePage.tsx
+++ b/gui/src/app/pages/HomePage/HomePage.tsx
@@ -132,7 +132,7 @@ type RightViewProps = {
     width: number
     height: number
     dataFileContent: string
-    saveDataFileContent: (text: string) => void
+    saveDataFileContent: () => void
     editedDataFileContent: string
     setEditedDataFileContent: (text: string) => void
     compiledMainJsUrl?: string


### PR DESCRIPTION
With the new data model structure, the text being returned in onSaveContent is no longer used. So I've removed that parameter.