### PR TITLE
Move monaco's JS to its own rollup chunk

### DIFF
--- a/gui/vite.config.ts
+++ b/gui/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
       output: {
         manualChunks: {
           monaco: ["monaco-editor", "@monaco-editor/react"],
+          utilities: ["jszip", "@octokit/rest"],
         },
       },
     },

--- a/gui/vite.config.ts
+++ b/gui/vite.config.ts
@@ -4,6 +4,15 @@ import { configDefaults, coverageConfigDefaults } from "vitest/config";
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          monaco: ["monaco-editor", "@monaco-editor/react"],
+        },
+      },
+    },
+  },
   test: {
     // note for testing: mockReset clears all spies/mocks and resets to empty function,
     // while restoreMocks: true calls .mockRestore() thereby clearing spies & mock


### PR DESCRIPTION
See #109

Even for a local preview this does seem to improve the load time of the main page UI. The output of `yarn build` is now:


```
dist/index.html                               0.69 kB │ gzip:   0.36 kB
dist/assets/StanModelWorker-BIcPRCbH.js       6.69 kB
dist/assets/codicon-DWH9l-dS.ttf             79.84 kB
dist/assets/stancWorker-1gYcNykd.js       1,842.68 kB
dist/assets/index-CKdHn2_2.css                3.45 kB │ gzip:   1.02 kB
dist/assets/monaco-DSq1fXy-.css             127.42 kB │ gzip:  20.40 kB
dist/assets/index-DaaP102i.js               598.90 kB │ gzip: 184.37 kB
dist/assets/plotly-cartesian-CygogzrV.js  1,345.80 kB │ gzip: 462.72 kB
dist/assets/monaco-DRY7gfXQ.js            2,298.03 kB │ gzip: 598.19 kB
```