### PR TITLE
Set example links to replace current history item

### DIFF
--- a/gui/src/app/pages/HomePage/LeftPanel.tsx
+++ b/gui/src/app/pages/HomePage/LeftPanel.tsx
@@ -80,7 +80,9 @@ const LeftPanel: FunctionComponent<LeftPanelProps> = ({
 
         {examplesStanies.map((stanie, i) => (
           <div key={i} style={{ margin: 5 }}>
-            <Link to={`?project=${stanie.link}`}>{stanie.name}</Link>
+            <Link replace to={`?project=${stanie.link}`}>
+              {stanie.name}
+            </Link>
           </div>
         ))}
         <hr />


### PR DESCRIPTION
A very minor improvement which occurred to me mere seconds after merging #130 

This makes it so clicking the examples replaces the current history item, which should always be the empty URL with no parameters (and therefore a relatively uninteresting history item). This makes it so clicking the various examples multiple times leads to a much more useful history/back button listing.