### PR TITLE
Simplify useStanSampler and related hooks

### DIFF
--- a/gui/src/app/RunPanel/RunPanel.tsx
+++ b/gui/src/app/RunPanel/RunPanel.tsx
@@ -9,15 +9,13 @@ import { FunctionComponent, useCallback } from "react";
 import { SamplingOpts } from "@SpCore/ProjectDataModel";
 import { Progress } from "@SpStanSampler/StanModelWorker";
 import StanSampler from "@SpStanSampler/StanSampler";
-import {
-  useSamplerProgress,
-  useSamplerStatus,
-} from "@SpStanSampler/useStanSampler";
+import { StanRun } from "@SpStanSampler/useStanSampler";
 
 type RunPanelProps = {
   width: number;
   height: number;
   sampler?: StanSampler;
+  latestRun: StanRun;
   data: any | undefined;
   dataIsSaved: boolean;
   samplingOpts: SamplingOpts;
@@ -27,12 +25,12 @@ const RunPanel: FunctionComponent<RunPanelProps> = ({
   width,
   height,
   sampler,
+  latestRun,
   data,
   dataIsSaved,
   samplingOpts,
 }) => {
-  const { status: runStatus, errorMessage } = useSamplerStatus(sampler);
-  const progress = useSamplerProgress(sampler);
+  const { status: runStatus, errorMessage, progress } = latestRun;
 
   const handleRun = useCallback(async () => {
     if (!sampler) return;

--- a/gui/src/app/SamplerOutputView/SamplerOutputView.tsx
+++ b/gui/src/app/SamplerOutputView/SamplerOutputView.tsx
@@ -5,8 +5,7 @@ import SummaryView from "@SpComponents/SummaryView";
 import TabWidget from "@SpComponents/TabWidget";
 import TracePlotsView from "@SpComponents/TracePlotsView";
 import { SamplingOpts } from "@SpCore/ProjectDataModel";
-import StanSampler from "@SpStanSampler/StanSampler";
-import { useSamplerOutput } from "@SpStanSampler/useStanSampler";
+import { StanRun } from "@SpStanSampler/useStanSampler";
 import { triggerDownload } from "@SpUtil/triggerDownload";
 import JSZip from "jszip";
 import { FunctionComponent, useCallback, useMemo, useState } from "react";
@@ -14,16 +13,16 @@ import { FunctionComponent, useCallback, useMemo, useState } from "react";
 type SamplerOutputViewProps = {
   width: number;
   height: number;
-  sampler: StanSampler;
+  latestRun: StanRun;
 };
 
 const SamplerOutputView: FunctionComponent<SamplerOutputViewProps> = ({
   width,
   height,
-  sampler,
+  latestRun,
 }) => {
-  const { draws, paramNames, numChains, computeTimeSec } =
-    useSamplerOutput(sampler);
+  const { draws, paramNames, computeTimeSec } = latestRun;
+  const numChains = latestRun.samplingOpts.num_chains;
 
   if (!draws || !paramNames || !numChains) return <span />;
   return (
@@ -34,7 +33,7 @@ const SamplerOutputView: FunctionComponent<SamplerOutputViewProps> = ({
       paramNames={paramNames}
       numChains={numChains}
       computeTimeSec={computeTimeSec}
-      samplingOpts={sampler.samplingOpts}
+      samplingOpts={latestRun.samplingOpts}
     />
   );
 };

--- a/gui/src/app/SamplerOutputView/SamplerOutputView.tsx
+++ b/gui/src/app/SamplerOutputView/SamplerOutputView.tsx
@@ -21,19 +21,17 @@ const SamplerOutputView: FunctionComponent<SamplerOutputViewProps> = ({
   height,
   latestRun,
 }) => {
-  const { draws, paramNames, computeTimeSec } = latestRun;
-  const numChains = latestRun.samplingOpts.num_chains;
+  const { draws, paramNames, computeTimeSec, samplingOpts } = latestRun;
 
-  if (!draws || !paramNames || !numChains) return <span />;
+  if (!draws || !paramNames || !samplingOpts) return <span />;
   return (
     <DrawsDisplay
       width={width}
       height={height}
       draws={draws}
       paramNames={paramNames}
-      numChains={numChains}
       computeTimeSec={computeTimeSec}
-      samplingOpts={latestRun.samplingOpts}
+      samplingOpts={samplingOpts}
     />
   );
 };
@@ -42,10 +40,9 @@ type DrawsDisplayProps = {
   width: number;
   height: number;
   draws: number[][];
-  numChains: number;
   paramNames: string[];
   computeTimeSec: number | undefined;
-  samplingOpts: SamplingOpts; // for including in exported zip
+  samplingOpts: SamplingOpts;
 };
 
 const tabs = [
@@ -80,11 +77,12 @@ const DrawsDisplay: FunctionComponent<DrawsDisplayProps> = ({
   height,
   draws,
   paramNames,
-  numChains,
   computeTimeSec,
   samplingOpts,
 }) => {
   const [currentTabId, setCurrentTabId] = useState("summary");
+
+  const numChains = samplingOpts.num_chains;
 
   const drawChainIds = useMemo(() => {
     return [...new Array(draws[0].length).keys()].map(

--- a/gui/src/app/StanSampler/StanSampler.ts
+++ b/gui/src/app/StanSampler/StanSampler.ts
@@ -1,7 +1,6 @@
 import { SamplingOpts } from "@SpCore/ProjectDataModel";
 import { Replies, Requests } from "@SpStanSampler/StanModelWorker";
 import StanWorkerUrl from "@SpStanSampler/StanModelWorker?worker&url";
-import React from "react";
 import type { SamplerParams } from "tinystan";
 import { type StanRunAction } from "./useStanSampler";
 
@@ -13,24 +12,26 @@ export type StanSamplerStatus =
   | "completed"
   | "failed";
 
+type StanSamplerAndCleanup = {
+  sampler: StanSampler;
+  cleanup: () => void;
+};
+
 class StanSampler {
   #worker: Worker | undefined;
   #samplingStartTimeSec: number = 0;
 
   private constructor(
     private compiledUrl: string,
-    private update: React.Dispatch<StanRunAction>,
+    private update: (action: StanRunAction) => void,
   ) {
     this._initialize();
   }
 
   static __unsafe_create(
     compiledUrl: string,
-    update: React.Dispatch<StanRunAction>,
-  ): {
-    sampler: StanSampler;
-    cleanup: () => void;
-  } {
+    update: (action: StanRunAction) => void,
+  ): StanSamplerAndCleanup {
     const sampler = new StanSampler(compiledUrl, update);
     const cleanup = () => {
       console.log("terminating model worker");

--- a/gui/src/app/StanSampler/useStanSampler.ts
+++ b/gui/src/app/StanSampler/useStanSampler.ts
@@ -1,13 +1,15 @@
-import { defaultSamplingOpts, SamplingOpts } from "@SpCore/ProjectDataModel";
-import { Progress } from "@SpStanSampler/StanModelWorker";
-import StanSampler, { StanSamplerStatus } from "@SpStanSampler/StanSampler";
+import { type SamplingOpts } from "@SpCore/ProjectDataModel";
+import { type Progress } from "@SpStanSampler/StanModelWorker";
+import StanSampler, {
+  type StanSamplerStatus,
+} from "@SpStanSampler/StanSampler";
 import { useEffect, useReducer, useState } from "react";
 
 export type StanRun = {
   status: StanSamplerStatus;
   errorMessage: string;
   progress?: Progress;
-  samplingOpts: SamplingOpts;
+  samplingOpts?: SamplingOpts;
   draws?: number[][];
   paramNames?: string[];
   computeTimeSec?: number;
@@ -16,7 +18,6 @@ export type StanRun = {
 const initialStanRun: StanRun = {
   status: "",
   errorMessage: "",
-  samplingOpts: defaultSamplingOpts,
 };
 
 export type StanRunAction =

--- a/gui/src/app/StanSampler/useStanSampler.ts
+++ b/gui/src/app/StanSampler/useStanSampler.ts
@@ -1,98 +1,101 @@
+import { defaultSamplingOpts, SamplingOpts } from "@SpCore/ProjectDataModel";
 import { Progress } from "@SpStanSampler/StanModelWorker";
 import StanSampler, { StanSamplerStatus } from "@SpStanSampler/StanSampler";
-import { useEffect, useState } from "react";
+import { useEffect, useReducer, useState } from "react";
+
+export type StanRun = {
+  status: StanSamplerStatus;
+  errorMessage: string;
+  progress?: Progress;
+  samplingOpts: SamplingOpts;
+  draws?: number[][];
+  paramNames?: string[];
+  computeTimeSec?: number;
+};
+
+const initialStanRun: StanRun = {
+  status: "",
+  errorMessage: "",
+  samplingOpts: defaultSamplingOpts,
+};
+
+export type StanRunAction =
+  | { type: "clear" }
+  | {
+      type: "statusUpdate";
+      status: StanSamplerStatus;
+      errorMessage?: string;
+    }
+  | {
+      type: "progressUpdate";
+      progress: Progress;
+    }
+  | {
+      type: "startSampling";
+      samplingOpts: SamplingOpts;
+    }
+  | {
+      type: "samplerReturn";
+      draws: number[][];
+      paramNames: string[];
+      computeTimeSec: number;
+    };
+
+export const StanRunReducer = (
+  state: StanRun,
+  action: StanRunAction,
+): StanRun => {
+  switch (action.type) {
+    case "clear":
+      return initialStanRun;
+    case "progressUpdate":
+      return { ...state, progress: action.progress };
+    case "statusUpdate":
+      if (action.errorMessage) {
+        return {
+          ...state,
+          status: action.status,
+          errorMessage: action.errorMessage,
+        };
+      }
+      return { ...state, status: action.status };
+    case "startSampling":
+      return {
+        status: "sampling",
+        errorMessage: "",
+        samplingOpts: action.samplingOpts,
+      };
+    case "samplerReturn":
+      return {
+        ...state,
+        status: "completed",
+        draws: action.draws,
+        paramNames: action.paramNames,
+        computeTimeSec: action.computeTimeSec,
+      };
+  }
+};
 
 const useStanSampler = (compiledMainJsUrl: string | undefined) => {
+  const [latestRun, update] = useReducer(StanRunReducer, initialStanRun);
+
   const [sampler, setSampler] = useState<StanSampler | undefined>(undefined);
+
   useEffect(() => {
+    update({ type: "clear" });
     if (!compiledMainJsUrl) {
       setSampler(undefined);
       return;
     }
-    const { sampler, cleanup: destructor } =
-      StanSampler.__unsafe_create(compiledMainJsUrl);
+    const { sampler, cleanup: destructor } = StanSampler.__unsafe_create(
+      compiledMainJsUrl,
+      update,
+    );
     setSampler(sampler);
     return destructor;
   }, [compiledMainJsUrl]);
 
-  return { sampler };
-};
-
-export const useSamplerStatus = (sampler: StanSampler | undefined) => {
-  const [status, setStatus] = useState<StanSamplerStatus>("");
-  const [errorMessage, setErrorMessage] = useState<string>("");
-  useEffect(() => {
-    if (!sampler) return;
-    let canceled = false;
-    setStatus(sampler.status);
-    const cb = () => {
-      if (canceled) return;
-      setStatus(sampler.status);
-      if (sampler.status === "failed") {
-        setErrorMessage(sampler.errorMessage);
-      }
-    };
-    sampler.onStatusChanged(cb);
-    return () => {
-      canceled = true;
-    };
-  }, [sampler]);
-  return { status, errorMessage };
-};
-
-export const useSamplerProgress = (sampler: StanSampler | undefined) => {
-  const [progress, setProgress] = useState<Progress | undefined>(undefined);
-  useEffect(() => {
-    setProgress(undefined);
-    if (!sampler) return;
-    let canceled = false;
-    const cb = (progress: Progress) => {
-      if (canceled) return;
-      setProgress(progress);
-    };
-    sampler.onProgress(cb);
-    return () => {
-      canceled = true;
-    };
-  }, [sampler]);
-  return progress;
-};
-
-export const useSamplerOutput = (sampler: StanSampler | undefined) => {
-  const [draws, setDraws] = useState<number[][] | undefined>();
-  const [paramNames, setParamNames] = useState<string[] | undefined>();
-  const [numChains, setNumChains] = useState<number | undefined>();
-  const [computeTimeSec, setComputeTimeSec] = useState<number | undefined>();
-
-  useEffect(() => {
-    let canceled = false;
-    if (!sampler) {
-      setDraws(undefined);
-      setParamNames(undefined);
-      setNumChains(undefined);
-      setComputeTimeSec(undefined);
-      return;
-    }
-    sampler.onStatusChanged(() => {
-      if (canceled) return;
-      if (sampler.status === "completed") {
-        setDraws(sampler.draws);
-        setParamNames(sampler.paramNames);
-        setNumChains(sampler.samplingOpts.num_chains);
-        setComputeTimeSec(sampler.computeTimeSec);
-      } else {
-        setDraws(undefined);
-        setParamNames(undefined);
-        setNumChains(undefined);
-        setComputeTimeSec(undefined);
-      }
-    });
-    return () => {
-      canceled = true;
-    };
-  }, [sampler]);
-
-  return { draws, paramNames, numChains, computeTimeSec };
+  return { sampler, latestRun };
 };
 
 export default useStanSampler;

--- a/gui/src/app/StanSampler/useStanSampler.ts
+++ b/gui/src/app/StanSampler/useStanSampler.ts
@@ -52,14 +52,11 @@ export const StanRunReducer = (
     case "progressUpdate":
       return { ...state, progress: action.progress };
     case "statusUpdate":
-      if (action.errorMessage) {
-        return {
-          ...state,
-          status: action.status,
-          errorMessage: action.errorMessage,
-        };
-      }
-      return { ...state, status: action.status };
+      return {
+        ...state,
+        status: action.status,
+        errorMessage: action.errorMessage ?? state.errorMessage,
+      };
     case "startSampling":
       return {
         status: "sampling",

--- a/gui/src/app/pages/HomePage/HomePage.tsx
+++ b/gui/src/app/pages/HomePage/HomePage.tsx
@@ -15,9 +15,7 @@ import {
 } from "@SpCore/ProjectDataModel";
 import LeftPanel from "@SpPages/LeftPanel";
 import TopBar from "@SpPages/TopBar";
-import useStanSampler, {
-  useSamplerStatus,
-} from "@SpStanSampler/useStanSampler";
+import useStanSampler from "@SpStanSampler/useStanSampler";
 import {
   FunctionComponent,
   useCallback,
@@ -240,9 +238,8 @@ const RightView: FunctionComponent<RightViewProps> = ({
     [update],
   );
 
-  const { sampler } = useStanSampler(compiledMainJsUrl);
-  const { status: samplerStatus } = useSamplerStatus(sampler);
-  const isSampling = samplerStatus === "sampling";
+  const { sampler, latestRun } = useStanSampler(compiledMainJsUrl);
+  const isSampling = latestRun.status === "sampling";
   return (
     <div className="Absolute" style={{ width, height }}>
       <div
@@ -269,6 +266,7 @@ const RightView: FunctionComponent<RightViewProps> = ({
           width={width}
           height={samplingOptsPanelHeight}
           sampler={sampler}
+          latestRun={latestRun}
           data={parsedData}
           dataIsSaved={!modelHasUnsavedDataFileChanges(data)}
           samplingOpts={data.samplingOpts}
@@ -282,13 +280,11 @@ const RightView: FunctionComponent<RightViewProps> = ({
           height: height - samplingOptsPanelHeight,
         }}
       >
-        {sampler && (
-          <SamplerOutputView
-            width={width}
-            height={height - samplingOptsPanelHeight}
-            sampler={sampler}
-          />
-        )}
+        <SamplerOutputView
+          width={width}
+          height={height - samplingOptsPanelHeight}
+          latestRun={latestRun}
+        />
       </div>
     </div>
   );

--- a/gui/test/app/StanSampler/useStanSampler.test.ts
+++ b/gui/test/app/StanSampler/useStanSampler.test.ts
@@ -2,7 +2,7 @@
 
 import { act, renderHook, waitFor } from "@testing-library/react";
 import "@vitest/web-worker";
-import { afterEach, describe, expect, onTestFinished, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import mockedLoad, {
   erroringCompiledMainJsUrl,
   erroringSamplingOpts,
@@ -217,7 +217,7 @@ describe("useStanSampler", () => {
       expect(result.current.latestRun.draws).toBeUndefined();
       expect(result.current.latestRun.paramNames).toBeUndefined();
       expect(result.current.latestRun.computeTimeSec).toBeUndefined();
-      expect(result.current.latestRun.samplingOpts).toBe(defaultSamplingOpts);
+      expect(result.current.latestRun.samplingOpts).toBeUndefined();
 
       const testingSamplingOpts = {
         ...defaultSamplingOpts,


### PR DESCRIPTION
This collapses a lot of the state management around the Stan model worker and its output into a reducer which is managed internally.

useStanSampler has two concerns:

1. Creating the worker thread, allowing us to call it, and managing cancellation/cleanup
2. Providing reactive access to the outputs of sampling

After this PR, these now exactly correspond to the two returned objects from the hook, `sampler` and `lastRun`. The later is a simple POD struct which supplants the existing useSamplerStatus, useProgress, and useSamplerOutputs hooks.