### PR TITLE
Clear analysis outputs when sampler is re-run

### DIFF
--- a/gui/src/app/FileEditor/TextEditor.tsx
+++ b/gui/src/app/FileEditor/TextEditor.tsx
@@ -50,7 +50,6 @@ const TextEditor: FunctionComponent<Props> = ({
   editedText,
   onSetEditedText,
   readOnly,
-  wordWrap,
   toolbarItems,
   language,
   label,
@@ -151,7 +150,7 @@ const TextEditor: FunctionComponent<Props> = ({
         options={{
           readOnly,
           domReadOnly: readOnly,
-          wordWrap: wordWrap ? "on" : "off",
+          wordWrap: "on",
         }}
       />
     </div>

--- a/gui/src/app/StanSampler/useStanSampler.ts
+++ b/gui/src/app/StanSampler/useStanSampler.ts
@@ -59,6 +59,8 @@ export const StanRunReducer = (
       };
     case "startSampling":
       return {
+        // preserve previous draws, paramNames, etc in case they are still being rendered while sampling progresses
+        ...state,
         status: "sampling",
         errorMessage: "",
         samplingOpts: action.samplingOpts,

--- a/gui/src/app/pages/HomePage/AnalysisPyWindow/AnalysisPyWindow.tsx
+++ b/gui/src/app/pages/HomePage/AnalysisPyWindow/AnalysisPyWindow.tsx
@@ -59,10 +59,10 @@ const LeftPane: FunctionComponent<LeftPaneProps> = ({
   }, [latestRun.draws]);
 
   const { data, update } = useContext(ProjectContext);
-  const { draws, paramNames, samplingOpts } = latestRun;
+  const { draws, paramNames, samplingOpts, status } = latestRun;
   const numChains = samplingOpts?.num_chains;
   const spData = useMemo(() => {
-    if (draws && numChains && paramNames) {
+    if (status === "completed" && draws && numChains && paramNames) {
       return {
         draws,
         paramNames,
@@ -71,7 +71,7 @@ const LeftPane: FunctionComponent<LeftPaneProps> = ({
     } else {
       return undefined;
     }
-  }, [draws, paramNames, numChains]);
+  }, [status, draws, numChains, paramNames]);
   return (
     <Splitter direction={SplitDirection.Vertical} initialSizes={[60, 40]}>
       <AnalysisPyFileEditor

--- a/gui/src/app/pages/HomePage/AnalysisPyWindow/AnalysisPyWindow.tsx
+++ b/gui/src/app/pages/HomePage/AnalysisPyWindow/AnalysisPyWindow.tsx
@@ -2,6 +2,7 @@ import {
   FunctionComponent,
   RefObject,
   useContext,
+  useEffect,
   useMemo,
   useRef,
 } from "react";
@@ -19,6 +20,12 @@ const AnalysisPyWindow: FunctionComponent<AnalysisPyWindowProps> = ({
   latestRun,
 }) => {
   const imagesRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (imagesRef.current) {
+      imagesRef.current.innerHTML = "";
+    }
+  }, [latestRun.draws]);
 
   return (
     <Splitter>
@@ -44,6 +51,12 @@ const LeftPane: FunctionComponent<LeftPaneProps> = ({
   latestRun,
 }) => {
   const consoleRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (consoleRef.current) {
+      consoleRef.current.innerHTML = "";
+    }
+  }, [latestRun.draws]);
 
   const { data, update } = useContext(ProjectContext);
   const { draws, paramNames, samplingOpts } = latestRun;

--- a/gui/src/app/pyodide/AnalysisPyFileEditor.tsx
+++ b/gui/src/app/pyodide/AnalysisPyFileEditor.tsx
@@ -2,6 +2,7 @@ import {
   FunctionComponent,
   RefObject,
   useCallback,
+  useEffect,
   useMemo,
   useState,
 } from "react";
@@ -64,6 +65,10 @@ const AnalysisPyFileEditor: FunctionComponent<Props> = ({
   const hasData = useMemo(() => {
     return spData !== undefined;
   }, [spData]);
+
+  useEffect(() => {
+    setStatus("idle");
+  }, [spData, fileContent]);
 
   const handleRun = useCallback(() => {
     if (status === "running") {


### PR DESCRIPTION
This prevents having plots, etc that show draws from a previous run being left around in the UI