### PR TITLE
Improve data.R integration

### DIFF
--- a/gui/src/app/pages/HomePage/DataGenerationWindow/DataGenerationWindow.tsx
+++ b/gui/src/app/pages/HomePage/DataGenerationWindow/DataGenerationWindow.tsx
@@ -38,22 +38,33 @@ const DataGenerationChildWindow: FunctionComponent<
   const consoleRef = useRef<HTMLDivElement | null>(null);
 
   const handleSetData = useCallback(
-    (data: any) => {
-      update({
-        type: "editFile",
-        content: JSON.stringify(data, null, 2),
-        filename: ProjectKnownFiles.DATAFILE,
-      });
-      update({ type: "commitFile", filename: ProjectKnownFiles.DATAFILE });
-      // Use "stan-playground" prefix to distinguish from console output of the running code
-      writeConsoleOutToDiv(
-        consoleRef,
-        "[stan-playground] Data updated",
-        "stdout",
-      );
+    (newData: unknown) => {
+      const dataJson = JSON.stringify(newData, null, 2);
+
+      if (dataJson !== data.dataFileContent) {
+        update({
+          type: "editFile",
+          content: dataJson,
+          filename: ProjectKnownFiles.DATAFILE,
+        });
+        update({ type: "commitFile", filename: ProjectKnownFiles.DATAFILE });
+        // Use "stan-playground" prefix to distinguish from console output of the running code
+        writeConsoleOutToDiv(
+          consoleRef,
+          "[stan-playground] Data updated",
+          "stdout",
+        );
+      } else {
+        writeConsoleOutToDiv(
+          consoleRef,
+          "[stan-playground] Data unchanged",
+          "stdout",
+        );
+      }
     },
-    [update, consoleRef],
+    [update, consoleRef, data.dataFileContent],
   );
+
   const EditorComponent =
     language === "python" ? DataPyFileEditor : DataRFileEditor;
   return (

--- a/gui/src/app/pages/HomePage/DataGenerationWindow/DataPyFileEditor.tsx
+++ b/gui/src/app/pages/HomePage/DataGenerationWindow/DataPyFileEditor.tsx
@@ -78,6 +78,7 @@ const DataPyFileEditor: FunctionComponent<Props> = ({
   const toolbarItems: ToolbarItem[] = useMemo(
     () =>
       getDataGenerationToolbarItems({
+        name: "pyodide",
         status,
         runnable: fileContent === editedFileContent,
         onRun: handleRun,

--- a/gui/src/app/pages/HomePage/DataGenerationWindow/DataRFileEditor.tsx
+++ b/gui/src/app/pages/HomePage/DataGenerationWindow/DataRFileEditor.tsx
@@ -63,6 +63,9 @@ const DataRFileEditor: FunctionComponent<Props> = ({
       setStatus("running");
       const rCode =
         `
+# redirect install.packages to webr's version
+webr::shim_install()
+
 # Create a list to store printed statements
 print_log <- list()
 
@@ -87,6 +90,9 @@ print <- function(..., sep = " ", collapse = NULL) {
         fileContent +
         "\n\n" +
         `
+if (typeof(data) != "list") {
+  stop("[stan-playground] data must be a list")
+}
 result <- list(data = data, print_log = print_log)
 json_result <- jsonlite::toJSON(result, pretty = TRUE, auto_unbox = TRUE)
 json_result
@@ -131,6 +137,7 @@ json_result
   const toolbarItems: ToolbarItem[] = useMemo(
     () =>
       getDataGenerationToolbarItems({
+        name: "WebR",
         status,
         runnable: fileContent === editedFileContent,
         onRun: handleRun,

--- a/gui/src/app/pages/HomePage/DataGenerationWindow/DataRFileEditor.tsx
+++ b/gui/src/app/pages/HomePage/DataGenerationWindow/DataRFileEditor.tsx
@@ -5,9 +5,10 @@ import {
   useMemo,
   useState,
 } from "react";
-import { WebR } from "webr";
+import { RString, WebR } from "webr";
 import getDataGenerationToolbarItems from "./getDataGenerationToolbarItems";
 import TextEditor, { ToolbarItem } from "@SpComponents/TextEditor";
+import { writeConsoleOutToDiv } from "@SpPyodide/AnalysisPyFileEditor";
 
 type Props = {
   fileName: string;
@@ -60,32 +61,14 @@ const DataRFileEditor: FunctionComponent<Props> = ({
     try {
       const webR = await loadWebRInstance();
 
+      const shelter = await new webR.Shelter();
+
       setStatus("running");
       const rCode =
         `
 # redirect install.packages to webr's version
 webr::shim_install()
-
-# Create a list to store printed statements
-print_log <- list()
-
-# Check if original print function is already saved
-if (!exists("sp_original_print")) {
-  # Save the original print function
-  sp_original_print <- print
-}
-
-# Override the print function
-print <- function(..., sep = " ", collapse = NULL) {
-  # Capture the printed output
-  printed_output <- paste(..., sep = sep, collapse = collapse)
-
-  # Append to the print log
-  print_log <<- c(print_log, printed_output)
-
-  # Call the original print function
-  sp_original_print(printed_output)
-}
+\n\n
 ` +
         fileContent +
         "\n\n" +
@@ -93,37 +76,29 @@ print <- function(..., sep = " ", collapse = NULL) {
 if (typeof(data) != "list") {
   stop("[stan-playground] data must be a list")
 }
-result <- list(data = data, print_log = print_log)
-json_result <- jsonlite::toJSON(result, pretty = TRUE, auto_unbox = TRUE)
-json_result
+.SP_DATA <- jsonlite::toJSON(data, pretty = TRUE, auto_unbox = TRUE)
+.SP_DATA
             `;
-      const resultJson = await webR.evalRString(rCode);
-      const result = JSON.parse(resultJson);
 
-      if (setData && result.data) {
-        setData(result.data);
-      }
-      if (outputDiv.current && result.print_log) {
-        result.print_log.forEach((x: string) => {
-          const divElement = document.createElement("div");
-          divElement.style.color = "blue";
-          const preElement = document.createElement("pre");
-          divElement.appendChild(preElement);
-          preElement.textContent = x;
-          outputDiv.current?.appendChild(divElement);
+      try {
+        const ret = await shelter.captureR(rCode);
+        ret.output.forEach(({ type, data }) => {
+          if (type === "stdout" || type === "stderr") {
+            writeConsoleOutToDiv(outputDiv, data, type);
+          }
         });
+
+        const result = JSON.parse(await (ret.result as RString).toString());
+        if (setData) {
+          setData(result);
+        }
+      } finally {
+        shelter.purge();
       }
       setStatus("completed");
     } catch (e: any) {
       console.error(e);
-      if (outputDiv.current) {
-        const divElement = document.createElement("div");
-        divElement.style.color = "red";
-        const preElement = document.createElement("pre");
-        divElement.appendChild(preElement);
-        preElement.textContent = e.toString();
-        outputDiv.current.appendChild(divElement);
-      }
+      writeConsoleOutToDiv(outputDiv, e.toString(), "stderr");
       setStatus("failed");
     }
   }, [editedFileContent, fileContent, status, setData, outputDiv]);

--- a/gui/src/app/pages/HomePage/DataGenerationWindow/getDataGenerationToolbarItems.tsx
+++ b/gui/src/app/pages/HomePage/DataGenerationWindow/getDataGenerationToolbarItems.tsx
@@ -4,11 +4,12 @@ import { Help, PlayArrow } from "@mui/icons-material";
 
 const getDataGenerationToolbarItems = (o: {
   status: PyodideWorkerStatus;
+  name: string;
   runnable: boolean;
   onRun: () => void;
   onHelp: () => void;
 }): ToolbarItem[] => {
-  const { status, onRun, runnable, onHelp } = o;
+  const { status, onRun, runnable, onHelp, name } = o;
   const ret: ToolbarItem[] = [];
   ret.push({
     type: "button",
@@ -29,7 +30,7 @@ const getDataGenerationToolbarItems = (o: {
   let label: string;
   let color: string;
   if (status === "loading") {
-    label = "Loading pyodide...";
+    label = `Loading ${name}...`;
     color = "blue";
   } else if (status === "running") {
     label = "Running...";


### PR DESCRIPTION
Three small things:

1. Don't display "Loading pyodide" when we are in fact loading webr
2. Check to make sure `data` is a list before serializing (`data` is also the name of a built-in R function, which we were serializing before if you just run a blank file)
3. Call [webr::shim_install()](https://docs.r-wasm.org/webr/latest/packages.html#shimming-install.packages-for-webr)

The following script can now re-create the data in the disease transmission example:

```R
install.packages("outbreaks")

library(outbreaks)

N <- 763 # given in documentation

cases <- influenza_england_1978_school$in_bed
n_days <- length(cases)
ts <- 1:n_days
t0 <- 0 

# started with a single infection
y0 <- c(N-1, 1, 0)

data <- list(N=N, cases=cases, n_days=n_days, ts=ts, t0=t0, y0=y0)
```