### PR TITLE
hint text in stan editor

### DIFF
--- a/gui/src/app/FileEditor/StanFileEditor.tsx
+++ b/gui/src/app/FileEditor/StanFileEditor.tsx
@@ -210,24 +210,16 @@ const StanFileEditor: FunctionComponent<Props> = ({
 
   const isCompiling = compileStatus === "compiling";
 
-  const messagePaneNeeded = syntaxWindowVisible || !editedFileContent;
-
-  const window = messagePaneNeeded ? (
-    editedFileContent ? (
-      <StanCompileResultWindow
-        stancErrors={stancErrors}
-        onClose={() => setSyntaxWindowVisible(false)}
-      />
-    ) : (
-      <div className="StanEditorDefaultText">
-        Begin editing or select an example from the left panel
-      </div>
-    )
+  const window = syntaxWindowVisible ? (
+    <StanCompileResultWindow
+      stancErrors={stancErrors}
+      onClose={() => setSyntaxWindowVisible(false)}
+    />
   ) : (
     <></>
   );
 
-  const initialSizes = messagePaneNeeded ? [60, 40] : [100, 0];
+  const initialSizes = syntaxWindowVisible ? [60, 40] : [100, 0];
 
   return (
     <Splitter direction={SplitDirection.Vertical} initialSizes={initialSizes}>
@@ -242,6 +234,7 @@ const StanFileEditor: FunctionComponent<Props> = ({
         readOnly={!isCompiling ? readOnly : true}
         toolbarItems={toolbarItems}
         codeMarkers={stancErrorsToCodeMarkers(stancErrors)}
+        hintTextOnEmpty="Begin editing or select an example from the left panel"
       />
       {window}
     </Splitter>

--- a/gui/src/app/FileEditor/TextEditor.tsx
+++ b/gui/src/app/FileEditor/TextEditor.tsx
@@ -27,6 +27,7 @@ type Props = {
   toolbarItems?: ToolbarItem[];
   label: string;
   codeMarkers?: CodeMarker[];
+  hintTextOnEmpty?: string;
 };
 
 export type ToolbarItem =
@@ -54,6 +55,7 @@ const TextEditor: FunctionComponent<Props> = ({
   language,
   label,
   codeMarkers,
+  hintTextOnEmpty,
 }) => {
   const handleChange = useCallback(
     (value: string | undefined) => {
@@ -99,6 +101,19 @@ const TextEditor: FunctionComponent<Props> = ({
       modelMarkers,
     );
   }, [codeMarkers, monacoInstance, editorInstance]);
+
+  useEffect(() => {
+    if (!editorInstance) return;
+    if (!hintTextOnEmpty) return;
+    if (text || editedText) {
+      return;
+    }
+    const contentWidget = createHintTextContentWidget(hintTextOnEmpty);
+    editorInstance.addContentWidget(contentWidget);
+    return () => {
+      editorInstance.removeContentWidget(contentWidget);
+    };
+  }, [text, editorInstance, editedText, hintTextOnEmpty]);
 
   /////////////////////////////////////////////////
 
@@ -225,6 +240,26 @@ const ToolbarItemComponent: FunctionComponent<{ item: ToolbarItem }> = ({
 
 const NotSelectable: FunctionComponent<PropsWithChildren> = ({ children }) => {
   return <div className="NotSelectable">{children}</div>;
+};
+
+const createHintTextContentWidget = (hintText: string) => {
+  return {
+    getDomNode: () => {
+      const node = document.createElement("div");
+      node.style.width = "max-content";
+      node.style.pointerEvents = "none";
+      node.textContent = hintText;
+      node.style.fontStyle = "italic";
+      return node;
+    },
+    getId: () => "hintText",
+    getPosition: () => {
+      return {
+        position: { lineNumber: 1, column: 1 },
+        preference: [editor.ContentWidgetPositionPreference.EXACT],
+      };
+    },
+  };
 };
 
 export default TextEditor;

--- a/gui/src/app/FileEditor/TextEditor.tsx
+++ b/gui/src/app/FileEditor/TextEditor.tsx
@@ -248,8 +248,8 @@ const createHintTextContentWidget = (hintText: string) => {
       const node = document.createElement("div");
       node.style.width = "max-content";
       node.style.pointerEvents = "none";
+      node.className = "EditorHintText";
       node.textContent = hintText;
-      node.style.fontStyle = "italic";
       return node;
     },
     getId: () => "hintText",

--- a/gui/src/localStyles.css
+++ b/gui/src/localStyles.css
@@ -192,3 +192,8 @@ span.EditorTitle {
   height: 100%;
   overflow: auto;
 }
+
+.EditorHintText {
+  font-style: italic;
+  color: #aaa;
+}


### PR DESCRIPTION
If stan editor is empty, display hint message in the editor "Begin editing or select an example from the left panel" using monaco's addContentWidget.

And... no longer abuses syntax error window for this purpose.

See discussion in #149 

![image](https://github.com/user-attachments/assets/93d932ec-f0fa-4c6d-8577-0e681f94ce79)
