### PR TITLE
Update TabWidget to use 'overflow="auto" for scrolling

### DIFF
--- a/gui/src/app/components/TabWidget.tsx
+++ b/gui/src/app/components/TabWidget.tsx
@@ -36,7 +36,7 @@ const TabWidget: FunctionComponent<TabWidgetProps> = ({ labels, children }) => {
           <Tab key={i} label={label} />
         ))}
       </Tabs>
-      <Box flex="1" overflow="scroll">
+      <Box flex="1" overflow="auto">
         {children.map((child, i) => (
           <CustomTabPanel
             key={i}


### PR DESCRIPTION
This change hides scrollbars when they are not needed. Here's what it looked like before the change. See lower-right corner.

![image](https://github.com/user-attachments/assets/61838498-9ba8-499f-ad66-0bb498424fd5)