### PR TITLE
Tweak plot output appearance

### DIFF
--- a/gui/src/app/Scripting/pyodide/pyodideWorker.ts
+++ b/gui/src/app/Scripting/pyodide/pyodideWorker.ts
@@ -147,7 +147,8 @@ patch_matplotlib(_SP_ADD_IMAGE)
 
     postamble += `
 import matplotlib.pyplot as plt
-plt.show()
+if len(plt.gcf().get_children()) > 1:
+    plt.show()
 `;
   }
 

--- a/gui/src/app/Scripting/webR/runR.ts
+++ b/gui/src/app/Scripting/webR/runR.ts
@@ -30,8 +30,6 @@ const captureOutputOptions = {
   captureStreams: true,
   captureConditions: false,
   captureGraphics: {
-    width: 340,
-    height: 340,
     bg: "white", // default: transparent
     pointsize: 12,
     capture: true,
@@ -103,6 +101,7 @@ invisible(.SP_DATA)`;
           // Set canvas size to image
           canvas.width = img.width;
           canvas.height = img.height;
+          canvas.style.width = "100%";
 
           // Draw image onto Canvas
           const ctx = canvas.getContext("2d");


### PR DESCRIPTION
- Prevents a white box from appearing whenever analysis.py is run without producing a plot
- Makes it so the plots in R resize as you drag the splitter, matching Python