### PR TITLE
Update toolbar, smarter hiding of labels

### DIFF
--- a/gui/src/app/FileEditor/StanFileEditor.tsx
+++ b/gui/src/app/FileEditor/StanFileEditor.tsx
@@ -1,5 +1,4 @@
 import { AutoFixHigh, Cancel, Settings } from "@mui/icons-material";
-import useMediaQuery from "@mui/material/useMediaQuery";
 import { SplitDirection, Splitter } from "@SpComponents/Splitter";
 import StanCompileResultWindow from "@SpComponents/StanCompileResultWindow";
 import TextEditor, { ToolbarItem } from "@SpComponents/TextEditor";
@@ -123,7 +122,6 @@ const StanFileEditor: FunctionComponent<Props> = ({
     }
   }, [fileContent, handleCompile, didInitialCompile]);
 
-  const showLabelsOnButtons = useMediaQuery("(min-width:600px)");
   const [syntaxWindowVisible, setSyntaxWindowVisible] = useState(false);
 
   const toolbarItems: ToolbarItem[] = useMemo(() => {
@@ -134,7 +132,7 @@ const StanFileEditor: FunctionComponent<Props> = ({
       ret.push({
         type: "button",
         icon: <Cancel />,
-        label: showLabelsOnButtons ? "Syntax error" : "",
+        label: "Syntax error",
         color: "darkred",
         tooltip: "Syntax error in Stan file",
         onClick: () => {
@@ -145,7 +143,7 @@ const StanFileEditor: FunctionComponent<Props> = ({
       ret.push({
         type: "button",
         icon: <Cancel />,
-        label: showLabelsOnButtons ? "Syntax warning" : "",
+        label: "Syntax warning",
         color: "blue",
         tooltip: "Syntax warning in Stan file",
         onClick: () => {
@@ -155,17 +153,15 @@ const StanFileEditor: FunctionComponent<Props> = ({
     }
 
     // auto format
-    if (!readOnly) {
-      if (editedFileContent) {
-        ret.push({
-          type: "button",
-          icon: <AutoFixHigh />,
-          tooltip: "Auto format this stan file",
-          label: showLabelsOnButtons ? "auto format" : undefined,
-          onClick: requestFormat,
-          color: "darkblue",
-        });
-      }
+    if (!readOnly && editedFileContent && validSyntax) {
+      ret.push({
+        type: "button",
+        icon: <AutoFixHigh />,
+        tooltip: "Auto format this stan file",
+        label: "Auto format",
+        onClick: requestFormat,
+        color: "darkblue",
+      });
     }
     if (editedFileContent && editedFileContent === fileContent) {
       if (compileStatus !== "compiling") {
@@ -173,7 +169,7 @@ const StanFileEditor: FunctionComponent<Props> = ({
           ret.push({
             type: "button",
             tooltip: "Compile Stan model",
-            label: "compile",
+            label: "Compile",
             icon: <Settings />,
             onClick: handleCompile,
             color: "darkblue",
@@ -183,7 +179,8 @@ const StanFileEditor: FunctionComponent<Props> = ({
       if (compileStatus !== "") {
         ret.push({
           type: "text",
-          label: compileMessage,
+          label:
+            compileMessage.charAt(0).toUpperCase() + compileMessage.slice(1),
           color:
             compileStatus === "compiled"
               ? "green"
@@ -200,7 +197,6 @@ const StanFileEditor: FunctionComponent<Props> = ({
     fileContent,
     handleCompile,
     requestFormat,
-    showLabelsOnButtons,
     validSyntax,
     compileStatus,
     compileMessage,

--- a/gui/src/app/FileEditor/StanFileEditor.tsx
+++ b/gui/src/app/FileEditor/StanFileEditor.tsx
@@ -1,7 +1,8 @@
 import { AutoFixHigh, Cancel, Settings } from "@mui/icons-material";
 import { SplitDirection, Splitter } from "@SpComponents/Splitter";
 import StanCompileResultWindow from "@SpComponents/StanCompileResultWindow";
-import TextEditor, { ToolbarItem } from "@SpComponents/TextEditor";
+import TextEditor from "@SpComponents/TextEditor";
+import { ToolbarItem } from "@SpComponents/ToolBar";
 import compileStanProgram from "@SpStanc/compileStanProgram";
 import { stancErrorsToCodeMarkers } from "@SpStanc/Linting";
 import useStanc from "@SpStanc/useStanc";

--- a/gui/src/app/FileEditor/TextEditor.tsx
+++ b/gui/src/app/FileEditor/TextEditor.tsx
@@ -1,9 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Editor, loader, useMonaco } from "@monaco-editor/react";
-import { Save } from "@mui/icons-material";
-import Button from "@mui/material/Button";
-import Link from "@mui/material/Link";
+
 import monacoAddStanLang from "@SpComponents/stanLang";
+import { ToolBar, ToolbarItem } from "@SpComponents/ToolBar";
 import { CodeMarker } from "@SpStanc/Linting";
 import { editor, MarkerSeverity } from "monaco-editor";
 import {
@@ -29,21 +28,6 @@ type Props = {
   codeMarkers?: CodeMarker[];
   contentOnEmpty?: string | HTMLSpanElement;
 };
-
-export type ToolbarItem =
-  | {
-      type: "button";
-      tooltip?: string;
-      label?: string;
-      icon?: any;
-      onClick: () => void;
-      color?: string;
-    }
-  | {
-      type: "text";
-      label: string;
-      color?: string;
-    };
 
 const TextEditor: FunctionComponent<Props> = ({
   text,
@@ -170,117 +154,6 @@ const toMonacoMarkerSeverity = (
       return MarkerSeverity.Hint;
     case "info":
       return MarkerSeverity.Info;
-  }
-};
-
-type ToolbarProps = {
-  items: ToolbarItem[];
-  label: string;
-  onSaveText: () => void;
-  edited: boolean;
-  readOnly: boolean;
-};
-
-const ToolBar: FunctionComponent<ToolbarProps> = ({
-  items,
-  label,
-  onSaveText,
-  edited,
-  readOnly,
-}) => {
-  const toolBarItems = useMemo(() => {
-    const editorItems: ToolbarItem[] = [];
-
-    if (!readOnly && edited) {
-      editorItems.push({
-        type: "button",
-        icon: <Save />,
-        onClick: onSaveText,
-        tooltip: "Save file",
-        label: "Save",
-      });
-    }
-
-    if (edited) {
-      editorItems.push({
-        type: "text",
-        label: "Edited",
-        color: "red",
-      });
-    }
-
-    if (readOnly) {
-      editorItems.push({
-        type: "text",
-        label: "Read Only",
-        color: "gray",
-      });
-    }
-
-    return editorItems.concat(items);
-  }, [edited, items, onSaveText, readOnly]);
-
-  return (
-    <div className="NotSelectable">
-      <div className="EditorMenuBar">
-        <span className="EditorTitle">{label}</span>
-        {toolBarItems &&
-          toolBarItems.map((item, i) => (
-            <ToolbarItemComponent key={i} item={item} />
-          ))}
-      </div>
-    </div>
-  );
-};
-
-const ToolbarItemComponent: FunctionComponent<{ item: ToolbarItem }> = ({
-  item,
-}) => {
-  if (item.type === "button") {
-    const { onClick, color, label, tooltip, icon } = item;
-    if (icon) {
-      return (
-        <span className="EditorToolbarItem" style={{ color }}>
-          <Button
-            startIcon={icon}
-            onClick={onClick}
-            disabled={!onClick}
-            color="inherit"
-            size="small"
-            title={tooltip}
-          >
-            {label && <span className="ToolbarButtonText">{label}</span>}
-          </Button>
-        </span>
-      );
-    } else {
-      return (
-        <span className="EditorToolbarItem">
-          <Link
-            onClick={onClick}
-            color={color || "gray"}
-            component="button"
-            underline="none"
-            title={tooltip}
-          >
-            {label}
-          </Link>
-          &nbsp;&nbsp;&nbsp;
-        </span>
-      );
-    }
-  } else if (item.type === "text") {
-    return (
-      <span
-        className="EditorToolbarItem"
-        style={{ color: item.color || "gray" }}
-        title={item.label}
-      >
-        {item.label}&nbsp;&nbsp;&nbsp;
-      </span>
-    );
-  } else {
-    return <span>unknown toolbar item type</span>;
   }
 };
 

--- a/gui/src/app/FileEditor/ToolBar.tsx
+++ b/gui/src/app/FileEditor/ToolBar.tsx
@@ -1,0 +1,125 @@
+import { FunctionComponent, useMemo } from "react";
+import { Save } from "@mui/icons-material";
+import Link from "@mui/material/Link";
+import IconButton from "@mui/material/IconButton";
+
+export type ToolbarItem =
+  | {
+      type: "button";
+      tooltip?: string;
+      label?: string;
+      icon?: any;
+      onClick: () => void;
+      color?: string;
+    }
+  | {
+      type: "text";
+      label: string;
+      color?: string;
+    };
+
+type ToolbarProps = {
+  items: ToolbarItem[];
+  label: string;
+  onSaveText: () => void;
+  edited: boolean;
+  readOnly: boolean;
+};
+
+export const ToolBar: FunctionComponent<ToolbarProps> = ({
+  items,
+  label,
+  onSaveText,
+  edited,
+  readOnly,
+}) => {
+  const toolBarItems = useMemo(() => {
+    const editorItems: ToolbarItem[] = [];
+
+    if (readOnly) {
+      editorItems.push({
+        type: "text",
+        label: "Read Only",
+        color: "gray",
+      });
+    } else if (edited) {
+      editorItems.push({
+        type: "button",
+        icon: <Save />,
+        onClick: onSaveText,
+        tooltip: "Save file",
+        label: "Save",
+      });
+      editorItems.push({
+        type: "text",
+        label: "Edited",
+        color: "red",
+      });
+    }
+
+    return editorItems.concat(items);
+  }, [edited, items, onSaveText, readOnly]);
+
+  return (
+    <div className="NotSelectable">
+      <div className="EditorMenuBar">
+        <span className="EditorTitle">{label}</span>
+        {toolBarItems &&
+          toolBarItems.map((item, i) => (
+            <ToolbarItemComponent key={i} item={item} />
+          ))}
+      </div>
+    </div>
+  );
+};
+
+const ToolbarItemComponent: FunctionComponent<{ item: ToolbarItem }> = ({
+  item,
+}) => {
+  if (item.type === "button") {
+    const { onClick, color, label, tooltip, icon } = item;
+    if (icon) {
+      return (
+        <span className="EditorToolbarItem" style={{ color }}>
+          <IconButton
+            onClick={onClick}
+            disabled={!onClick}
+            color="inherit"
+            size="small"
+            title={tooltip}
+          >
+            {icon}
+            {label && <span className="ToolbarButtonText">{label}</span>}
+          </IconButton>
+        </span>
+      );
+    } else {
+      return (
+        <span className="EditorToolbarItem">
+          <Link
+            onClick={onClick}
+            color={color || "gray"}
+            component="button"
+            underline="none"
+            title={tooltip}
+          >
+            {label}
+          </Link>
+          &nbsp;&nbsp;&nbsp;
+        </span>
+      );
+    }
+  } else if (item.type === "text") {
+    return (
+      <span
+        className="EditorToolbarItem"
+        style={{ color: item.color || "gray" }}
+        title={item.label}
+      >
+        {item.label}&nbsp;&nbsp;&nbsp;
+      </span>
+    );
+  } else {
+    return <span>unknown toolbar item type</span>;
+  }
+};

--- a/gui/src/app/Scripting/ScriptEditor.tsx
+++ b/gui/src/app/Scripting/ScriptEditor.tsx
@@ -1,6 +1,7 @@
 import { Help, PlayArrow } from "@mui/icons-material";
 import { SplitDirection, Splitter } from "@SpComponents/Splitter";
-import TextEditor, { ToolbarItem } from "@SpComponents/TextEditor";
+import TextEditor from "@SpComponents/TextEditor";
+import { ToolbarItem } from "@SpComponents/ToolBar";
 import { FileNames } from "@SpCore/FileMapping";
 import { ProjectContext } from "@SpCore/ProjectContextProvider";
 import { ProjectKnownFiles } from "@SpCore/ProjectDataModel";

--- a/gui/src/localStyles.css
+++ b/gui/src/localStyles.css
@@ -116,12 +116,15 @@ span.EditorToolbarItem {
   letter-spacing: normal;
   display: inline-block;
   white-space: normal;
+  padding-left: 5px;
+  font-size: 14px;
 }
 
 @container EditorMenuBar (max-width: 500px) {
   .ToolbarButtonText {
     display: none;
     width: 0;
+    padding: 0;
   }
   span.EditorToolbarItem {
     padding: 0px;

--- a/gui/src/localStyles.css
+++ b/gui/src/localStyles.css
@@ -84,28 +84,53 @@
 
 /* Text Editors ------ */
 
+:root {
+  --editor-menu-height: 30px;
+}
+
 .EditorMenuBar {
   background-color: lightgray;
-  height: 25px;
+  height: var(--editor-menu-height);
+  position: relative;
+  display: flex;
+  align-content: center;
+  align-items: center;
+  container-name: EditorMenuBar;
+  container-type: inline-size;
+  white-space: nowrap;
+  overflow-x: auto;
+  overflow-y: hidden;
 }
 
 .EditorWithToolbar {
-  height: calc(100% - 25px);
+  height: calc(100% - var(--editor-menu-height));
+}
+
+span.EditorToolbarItem {
+  padding-left: 15px;
+}
+
+.ToolbarButtonText {
+  text-transform: none;
+  font-weight: normal;
+  letter-spacing: normal;
+  display: inline-block;
+  white-space: normal;
+}
+
+@container EditorMenuBar (max-width: 500px) {
+  .ToolbarButtonText {
+    display: none;
+    width: 0;
+  }
+  span.EditorToolbarItem {
+    padding: 0px;
+  }
 }
 
 span.EditorTitle {
-  position: relative;
-  top: 1px;
   padding-left: 5px;
-}
-
-.EditedText {
-  color: #a33;
-  font-size: 12px;
-}
-
-.ReadOnlyText {
-  color: gray;
+  font-weight: 500;
 }
 
 .NotSelectable {


### PR DESCRIPTION
This is an alternative to #168 

Prior:
![image](https://github.com/user-attachments/assets/63e86b08-5a35-4133-8916-3713bb2c83aa)

Now:
![image](https://github.com/user-attachments/assets/5e84e3b3-2169-47f8-8177-ed26a350d470)


Main differences are centering the items and some clever CSS to automatically hide the text labels when the container gets too small. This replaces the `useMediaQuery` hook in StanEditor, which didn't quite work anyway