### PR TITLE
Hide minimap on editor

### DIFF
--- a/gui/src/app/FileEditor/TextEditor.tsx
+++ b/gui/src/app/FileEditor/TextEditor.tsx
@@ -136,6 +136,7 @@ const TextEditor: FunctionComponent<Props> = ({
           readOnly,
           domReadOnly: readOnly,
           wordWrap: "on",
+          minimap: { enabled: false },
         }}
       />
     </div>

--- a/gui/src/localStyles.css
+++ b/gui/src/localStyles.css
@@ -133,6 +133,7 @@ span.EditorToolbarItem {
 
 span.EditorTitle {
   padding-left: 5px;
+  padding-right: 5px;
   font-weight: 500;
 }
 


### PR DESCRIPTION
This primarily removes the "minimap" sidebar monaco provides:
![image](https://github.com/user-attachments/assets/70a7a561-d4a3-466e-af06-9f4d282e06c7)

This is not really necessary in our project and has always led to odd flickering with the splitters