### PR TITLE
Support Ctrl+Enter to run scripts

### DIFF
--- a/gui/src/app/FileEditor/TextEditor.tsx
+++ b/gui/src/app/FileEditor/TextEditor.tsx
@@ -103,7 +103,7 @@ const TextEditor: FunctionComponent<Props> = ({
 
   useEffect(() => {
     if (!editorInstance) return;
-    editorInstance.addAction({
+    const disposable = editorInstance.addAction({
       id: "save",
       label: "Save",
       keybindings: [KeyMod.CtrlCmd | KeyCode.KeyS],
@@ -113,14 +113,18 @@ const TextEditor: FunctionComponent<Props> = ({
         }
       },
     });
+    return () => {
+      disposable.dispose();
+    };
   }, [editorInstance, onSaveText, readOnly]);
 
   useEffect(() => {
     if (!editorInstance) return;
     if (!actions) return;
-    for (const action of actions) {
-      editorInstance.addAction(action);
-    }
+    const disposables = actions.map(editorInstance.addAction);
+    return () => {
+      disposables.forEach((d) => d.dispose());
+    };
   }, [actions, editorInstance]);
 
   const edited = useMemo(() => {

--- a/gui/src/app/FileEditor/TextEditor.tsx
+++ b/gui/src/app/FileEditor/TextEditor.tsx
@@ -4,7 +4,13 @@ import { Editor, loader, useMonaco } from "@monaco-editor/react";
 import monacoAddStanLang from "@SpComponents/stanLang";
 import { ToolBar, ToolbarItem } from "@SpComponents/ToolBar";
 import { CodeMarker } from "@SpStanc/Linting";
-import { editor, KeyCode, KeyMod, MarkerSeverity } from "monaco-editor";
+import {
+  editor,
+  IDisposable,
+  KeyCode,
+  KeyMod,
+  MarkerSeverity,
+} from "monaco-editor";
 import {
   FunctionComponent,
   useCallback,
@@ -121,7 +127,10 @@ const TextEditor: FunctionComponent<Props> = ({
   useEffect(() => {
     if (!editorInstance) return;
     if (!actions) return;
-    const disposables = actions.map(editorInstance.addAction);
+    const disposables: IDisposable[] = [];
+    for (const action of actions) {
+      disposables.push(editorInstance.addAction(action));
+    }
     return () => {
       disposables.forEach((d) => d.dispose());
     };

--- a/gui/src/app/FileEditor/ToolBar.tsx
+++ b/gui/src/app/FileEditor/ToolBar.tsx
@@ -47,7 +47,7 @@ export const ToolBar: FunctionComponent<ToolbarProps> = ({
         type: "button",
         icon: <Save />,
         onClick: onSaveText,
-        tooltip: "Save file",
+        tooltip: "Save file (Ctrl-S)",
         label: "Save",
       });
       editorItems.push({

--- a/gui/src/app/Scripting/ScriptEditor.tsx
+++ b/gui/src/app/Scripting/ScriptEditor.tsx
@@ -73,17 +73,19 @@ const ScriptEditor: FunctionComponent<ScriptEditorProps> = ({
     return content !== editedContent;
   }, [content, editedContent]);
 
-  const runCtrlEnter: editor.IActionDescriptor = useMemo(
-    () => ({
-      id: "run-script",
-      label: "Run Script",
-      keybindings: [KeyMod.CtrlCmd | KeyCode.Enter],
-      run: () => {
-        if (runnable && !unsavedChanges) {
-          runCode();
-        }
+  const runCtrlEnter: editor.IActionDescriptor[] = useMemo(
+    () => [
+      {
+        id: "run-script",
+        label: "Run Script",
+        keybindings: [KeyMod.CtrlCmd | KeyCode.Enter],
+        run: () => {
+          if (runnable && !unsavedChanges) {
+            runCode();
+          }
+        },
       },
-    }),
+    ],
     [runCode, runnable, unsavedChanges],
   );
 
@@ -117,7 +119,7 @@ const ScriptEditor: FunctionComponent<ScriptEditorProps> = ({
         onSaveText={onSaveText}
         toolbarItems={toolbarItems}
         contentOnEmpty={contentOnEmpty}
-        actions={[runCtrlEnter]}
+        actions={runCtrlEnter}
       />
       <ConsoleOutputWindow consoleRef={consoleRef} />
     </Split>

--- a/gui/src/app/Scripting/ScriptEditor.tsx
+++ b/gui/src/app/Scripting/ScriptEditor.tsx
@@ -13,6 +13,7 @@ import {
 } from "react";
 import { InterpreterStatus } from "./InterpreterTypes";
 import { Split } from "@geoffcox/react-splitter";
+import { editor, KeyCode, KeyMod } from "monaco-editor";
 
 const interpreterNames = { python: "pyodide", r: "webR" } as const;
 
@@ -72,6 +73,20 @@ const ScriptEditor: FunctionComponent<ScriptEditorProps> = ({
     return content !== editedContent;
   }, [content, editedContent]);
 
+  const runCtrlEnter: editor.IActionDescriptor = useMemo(
+    () => ({
+      id: "run-script",
+      label: "Run Script",
+      keybindings: [KeyMod.CtrlCmd | KeyCode.Enter],
+      run: () => {
+        if (runnable && !unsavedChanges) {
+          runCode();
+        }
+      },
+    }),
+    [runCode, runnable, unsavedChanges],
+  );
+
   const toolbarItems: ToolbarItem[] = useMemo(() => {
     return makeToolbar({
       status,
@@ -102,6 +117,7 @@ const ScriptEditor: FunctionComponent<ScriptEditorProps> = ({
         onSaveText={onSaveText}
         toolbarItems={toolbarItems}
         contentOnEmpty={contentOnEmpty}
+        actions={[runCtrlEnter]}
       />
       <ConsoleOutputWindow consoleRef={consoleRef} />
     </Split>
@@ -129,7 +145,7 @@ const makeToolbar = (o: {
   if (runnable) {
     ret.push({
       type: "button",
-      tooltip: "Run code to generate data",
+      tooltip: "Run code (Ctrl-Enter)",
       label: "Run",
       icon: <PlayArrow />,
       onClick: onRun,


### PR DESCRIPTION
TextEditor takes a generic list of [`IActionDescriptors`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor.IActionDescriptor.html), and ScriptEditor provides one that runs the current script