### PR TITLE
Minor visual tweaks

### DIFF
--- a/backend/stan-wasm-server/src/app/logic/compilation.py
+++ b/backend/stan-wasm-server/src/app/logic/compilation.py
@@ -93,7 +93,8 @@ async def compile_stan_program(
     """
     try:
         job_main = get_job_source_file(job_dir)
-        cmd = f"emmake make {job_main.with_suffix('.js')} && emstrip {job_main.with_suffix('.wasm')}"
+        cmd = f"emmake make STANCFLAGS=--filename-in-msg=main.stan {job_main.with_suffix('.js')} \
+            && emstrip {job_main.with_suffix('.wasm')}"
         logger.info("Compiling in %s", job_dir)
         before = time.time()
         process = await asyncio.create_subprocess_shell(

--- a/gui/package.json
+++ b/gui/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
-    "@fi-sci/misc": "^0.0.8",
     "@geoffcox/react-splitter": "^2.1.2",
     "@monaco-editor/react": "^4.6.0",
     "@mui/icons-material": "^5.16.5",

--- a/gui/src/app/FileEditor/StanCompileResultWindow.tsx
+++ b/gui/src/app/FileEditor/StanCompileResultWindow.tsx
@@ -1,6 +1,6 @@
 import { StancErrors } from "@SpStanc/Types";
-import { SmallIconButton } from "@fi-sci/misc";
 import { Close, Done } from "@mui/icons-material";
+import IconButton from "@mui/material/IconButton";
 import { FunctionComponent } from "react";
 
 type Props = {
@@ -45,7 +45,9 @@ const StanCompileResultWindow: FunctionComponent<Props> = ({
 
   return (
     <div className="ErrorsWindow">
-      <SmallIconButton icon={<Close />} onClick={onClose} />
+      <IconButton size="small" onClick={onClose} title="Close">
+        <Close fontSize="inherit" />
+      </IconButton>
       {content}
     </div>
   );

--- a/gui/src/app/RunPanel/RunPanel.tsx
+++ b/gui/src/app/RunPanel/RunPanel.tsx
@@ -82,7 +82,11 @@ const RunPanel: FunctionComponent<RunPanelProps> = ({
           {runStatus === "completed" && <div>done sampling</div>}
           {runStatus === "failed" && (
             <div>
-              failed: {errorMessage} (see browser console for more details)
+              Sampling failed!
+              <pre className="SamplerError">{errorMessage}</pre>
+              <span className="details">
+                (see browser console for more details)
+              </span>
             </div>
           )}
         </div>

--- a/gui/src/app/SamplerOutputView/SamplerOutputView.tsx
+++ b/gui/src/app/SamplerOutputView/SamplerOutputView.tsx
@@ -1,4 +1,3 @@
-import { SmallIconButton } from "@fi-sci/misc";
 import { Download } from "@mui/icons-material";
 import HistsView from "@SpComponents/HistsView";
 import SummaryView from "@SpComponents/SummaryView";
@@ -10,6 +9,7 @@ import JSZip from "jszip";
 import { FunctionComponent, useCallback, useMemo, useState } from "react";
 import TracePlotsView from "./TracePlotsView";
 import Button from "@mui/material/Button";
+import { IconButton } from "@mui/material";
 
 type SamplerOutputViewProps = {
   latestRun: StanRun;
@@ -143,18 +143,21 @@ const DrawsView: FunctionComponent<DrawsViewProps> = ({
   return (
     <div className="DrawsTable">
       <div>
-        <SmallIconButton
-          icon={<Download />}
-          label="Export to single .csv"
-          onClick={handleExportToCsv}
-        />
+        <IconButton size="small" title="Download" onClick={handleExportToCsv}>
+          <Download fontSize="inherit" />
+          &nbsp;Export to single .csv
+        </IconButton>
         &nbsp;
-        <SmallIconButton
-          icon={<Download />}
-          label="Export to multiple .csv"
+        <IconButton
+          size="small"
+          title="Download"
           onClick={handleExportToMultipleCsvs}
-        />
+        >
+          <Download fontSize="inherit" />
+          &nbsp;Export to multiple .csv
+        </IconButton>
       </div>
+      <br />
       <table className="draws-table">
         <thead>
           <tr>

--- a/gui/src/localStyles.css
+++ b/gui/src/localStyles.css
@@ -22,6 +22,11 @@
   font-size: smaller;
 }
 
+.SamplerError {
+  color: red;
+  white-space: pre-wrap;
+}
+
 /* Compilation Results (StanCompileResultWindow) */
 .ErrorsWindow {
   height: 100%;

--- a/gui/vite.config.ts
+++ b/gui/vite.config.ts
@@ -5,6 +5,7 @@ import { configDefaults, coverageConfigDefaults } from "vitest/config";
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  optimizeDeps: { exclude: ["pyodide"] },
   build: {
     rollupOptions: {
       output: {

--- a/gui/yarn.lock
+++ b/gui/yarn.lock
@@ -549,11 +549,6 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.0.tgz#a5417ae8427873f1dd08b70b3574b453e67b5f7f"
   integrity sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==
 
-"@fi-sci/misc@^0.0.8":
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/@fi-sci/misc/-/misc-0.0.8.tgz#56b0c5402fc64df873c8a7b0d65966c3df3f0dd7"
-  integrity sha512-lhbKCriIv9TxBw3xSZ/q7mlfVDc+OsJ1x6jesyeHEVMdqqYHDIRTZTdUIrnA0jdL4nMj3FbYNHE49Z7K+iouiQ==
-
 "@floating-ui/core@^1.6.0":
   version "1.6.4"
   resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.6.4.tgz#0140cf5091c8dee602bff9da5ab330840ff91df6"


### PR DESCRIPTION
- When the sampler fails, the current output is pretty messy. This adds some light formatting. The easiest way to observe this is delete a variable from data.json
- A few more MUI button element changes, and a bit of extra space in the "draws" output tab