### PR TITLE
reduce redundant compile jobs, cache main.js URL

### DIFF
--- a/gui/src/app/FileEditor/StanFileEditor.tsx
+++ b/gui/src/app/FileEditor/StanFileEditor.tsx
@@ -5,7 +5,6 @@ import TextEditor from "@SpComponents/TextEditor";
 import { ToolbarItem } from "@SpComponents/ToolBar";
 import compileStanProgram from "@SpStanc/compileStanProgram";
 import { stancErrorsToCodeMarkers } from "@SpStanc/Linting";
-import { checkMainJsUrlCache } from "@SpStanc/mainJsUrlCache";
 import useStanc from "@SpStanc/useStanc";
 import {
   FunctionComponent,
@@ -97,16 +96,6 @@ const StanFileEditor: FunctionComponent<Props> = ({
     compileStatus,
     setCompiledUrl,
   ]);
-
-  useEffect(() => {
-    // if the stan program has already been compiled, and the record of that is in the cache,
-    // then call handleCompile, which will end up loading from the cache
-    checkMainJsUrlCache(fileContent).then((mainJsUrl) => {
-      if (mainJsUrl) {
-        handleCompile();
-      }
-    });
-  }, [fileContent, handleCompile]);
 
   const [syntaxWindowVisible, setSyntaxWindowVisible] = useState(false);
 

--- a/gui/src/app/FileEditor/StanFileEditor.tsx
+++ b/gui/src/app/FileEditor/StanFileEditor.tsx
@@ -5,6 +5,7 @@ import TextEditor from "@SpComponents/TextEditor";
 import { ToolbarItem } from "@SpComponents/ToolBar";
 import compileStanProgram from "@SpStanc/compileStanProgram";
 import { stancErrorsToCodeMarkers } from "@SpStanc/Linting";
+import { checkMainJsUrlCache } from "@SpStanc/mainJsUrlCache";
 import useStanc from "@SpStanc/useStanc";
 import {
   FunctionComponent,
@@ -79,16 +80,6 @@ const StanFileEditor: FunctionComponent<Props> = ({
     setCompiledUrl(mainJsUrl);
     setCompileStatus("compiled");
     setTheStanFileContentThasHasBeenCompiled(fileContent);
-
-    // record in local storage that we compiled this particular stan file
-    try {
-      const key = getKeyNameForCompiledFile(stanWasmServerUrl, fileContent);
-      const value = JSON.stringify({ mainJsUrl });
-      localStorage.setItem(key, value);
-    } catch (e: any) {
-      console.error("Problem recording compiled file in local storage");
-      console.error(e);
-    }
   }, [fileContent, setCompiledUrl]);
 
   useEffect(() => {
@@ -107,21 +98,15 @@ const StanFileEditor: FunctionComponent<Props> = ({
     setCompiledUrl,
   ]);
 
-  const [didInitialCompile, setDidInitialCompile] = useState(false);
   useEffect(() => {
-    // if we think this has been compiled before, let's go ahead and compile it (should be in cache on server)
-    // but we are only going to do this on initial load
-    if (didInitialCompile) return;
-    const stanWasmServerUrl = localStorage.getItem("stanWasmServerUrl") || "";
-    if (!stanWasmServerUrl) return;
-    const key = getKeyNameForCompiledFile(stanWasmServerUrl, fileContent);
-    const value = localStorage.getItem(key);
-    if (!value) return;
-    handleCompile();
-    if (fileContent) {
-      setDidInitialCompile(true);
-    }
-  }, [fileContent, handleCompile, didInitialCompile]);
+    // if the stan program has already been compiled, and the record of that is in the cache,
+    // then call handleCompile, which will end up loading from the cache
+    checkMainJsUrlCache(fileContent).then((mainJsUrl) => {
+      if (mainJsUrl) {
+        handleCompile();
+      }
+    });
+  }, [fileContent, handleCompile]);
 
   const [syntaxWindowVisible, setSyntaxWindowVisible] = useState(false);
 
@@ -241,24 +226,6 @@ const StanFileEditor: FunctionComponent<Props> = ({
       {window}
     </Split>
   );
-};
-
-const getKeyNameForCompiledFile = (
-  stanWasmServerUrl: string,
-  stanFileContent: string,
-) => {
-  return `compiled-file|${stanWasmServerUrl}|${stringChecksum(stanFileContent)}`;
-};
-
-const stringChecksum = (str: string) => {
-  let hash = 0;
-  if (str.length == 0) return hash;
-  for (let i = 0; i < str.length; i++) {
-    const char = str.charCodeAt(i);
-    hash = (hash << 5) - hash + char;
-    hash = hash & hash; // Convert to 32bit integer
-  }
-  return hash;
 };
 
 export default StanFileEditor;

--- a/gui/src/app/compileStanProgram/compileStanProgram.ts
+++ b/gui/src/app/compileStanProgram/compileStanProgram.ts
@@ -1,9 +1,18 @@
+import { checkMainJsUrlCache, setToMainJsUrlCache } from "./mainJsUrlCache";
+
 const compileStanProgram = async (
   stanWasmServerUrl: string,
   stanProgram: string,
   onStatus: (s: string) => void,
 ): Promise<{ mainJsUrl?: string }> => {
   try {
+    onStatus("checking cache");
+    const downloadMainJsUrlFromCache = await checkMainJsUrlCache(stanProgram);
+    if (downloadMainJsUrlFromCache) {
+      onStatus("compiled");
+      return { mainJsUrl: downloadMainJsUrlFromCache };
+    }
+
     onStatus("initiating job");
     const initiateJobUrl = `${stanWasmServerUrl}/job/initiate`;
     // post
@@ -55,6 +64,8 @@ const compileStanProgram = async (
     }
 
     const downloadMainJsUrl = `${stanWasmServerUrl}/job/${job_id}/download/main.js`;
+
+    setToMainJsUrlCache(stanProgram, downloadMainJsUrl);
 
     // download to make sure it is there
     onStatus("Checking download of main.js");

--- a/gui/src/app/compileStanProgram/compileStanProgram.ts
+++ b/gui/src/app/compileStanProgram/compileStanProgram.ts
@@ -7,7 +7,10 @@ const compileStanProgram = async (
 ): Promise<{ mainJsUrl?: string }> => {
   try {
     onStatus("checking cache");
-    const downloadMainJsUrlFromCache = await checkMainJsUrlCache(stanProgram);
+    const downloadMainJsUrlFromCache = await checkMainJsUrlCache(
+      stanProgram,
+      stanWasmServerUrl,
+    );
     if (downloadMainJsUrlFromCache) {
       onStatus("compiled");
       return { mainJsUrl: downloadMainJsUrlFromCache };

--- a/gui/src/app/compileStanProgram/mainJsUrlCache.ts
+++ b/gui/src/app/compileStanProgram/mainJsUrlCache.ts
@@ -16,7 +16,6 @@ export const checkMainJsUrlCache = async (
     // check to see if the url is still valid
     const exists = await checkRemoteFileExists(url);
     if (!exists) {
-      console.warn("mainJsCache url no longer exists");
       delete cache[stanProgramHash];
       localStorage.setItem("mainJsCache", JSON.stringify(cache));
       return null;

--- a/gui/src/app/compileStanProgram/mainJsUrlCache.ts
+++ b/gui/src/app/compileStanProgram/mainJsUrlCache.ts
@@ -1,5 +1,6 @@
 export const checkMainJsUrlCache = async (
   stanProgram: string,
+  baseStanWasmServerUrl: string,
 ): Promise<string | null> => {
   const mainJsCache = localStorage.getItem("mainJsCache");
   if (!mainJsCache) return null;
@@ -8,6 +9,10 @@ export const checkMainJsUrlCache = async (
     const stanProgramHash = stringChecksum(stanProgram);
     const url = cache[stanProgramHash];
     if (!url) return null;
+    if (!url.startsWith(baseStanWasmServerUrl)) {
+      // the url is not from the current server
+      return null;
+    }
     // check to see if the url is still valid
     const exists = await checkRemoteFileExists(url);
     if (!exists) {

--- a/gui/src/app/compileStanProgram/mainJsUrlCache.ts
+++ b/gui/src/app/compileStanProgram/mainJsUrlCache.ts
@@ -1,0 +1,69 @@
+export const checkMainJsUrlCache = async (
+  stanProgram: string,
+): Promise<string | null> => {
+  const mainJsCache = localStorage.getItem("mainJsCache");
+  if (!mainJsCache) return null;
+  try {
+    const cache = JSON.parse(mainJsCache);
+    const stanProgramHash = stringChecksum(stanProgram);
+    const url = cache[stanProgramHash];
+    if (!url) return null;
+    // check to see if the url is still valid
+    const exists = await checkRemoteFileExists(url);
+    if (!exists) {
+      console.warn("mainJsCache url no longer exists");
+      delete cache[stanProgramHash];
+      localStorage.setItem("mainJsCache", JSON.stringify(cache));
+      return null;
+    }
+    return url;
+  } catch (e) {
+    console.error("Problem parsing mainJsCache");
+    console.error(e);
+    try {
+      localStorage.removeItem("mainJsCache");
+    } catch (e) {
+      console.error("Problem removing mainJsCache");
+      console.error(e);
+    }
+    return null;
+  }
+};
+
+export const setToMainJsUrlCache = (stanProgram: string, url: string) => {
+  try {
+    const mainJsCache = localStorage.getItem("mainJsCache");
+    const stanProgramHash = stringChecksum(stanProgram);
+    let cache = mainJsCache ? JSON.parse(mainJsCache) : {};
+    cache = cleanupIfGettingTooBig(cache);
+    cache[stanProgramHash] = url;
+    localStorage.setItem("mainJsCache", JSON.stringify(cache));
+  } catch (e) {
+    console.error("Problem setting mainJsCache");
+    console.error(e);
+  }
+};
+
+const cleanupIfGettingTooBig = (cache: { [key: string]: string }) => {
+  // for now we just clear the whole thing if it's getting too big
+  if (Object.keys(cache).length > 50) {
+    return {};
+  }
+  return cache;
+};
+
+const stringChecksum = (str: string) => {
+  let hash = 0;
+  if (str.length == 0) return hash;
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash = hash & hash; // Convert to 32bit integer
+  }
+  return hash;
+};
+
+const checkRemoteFileExists = async (url: string): Promise<boolean> => {
+  const response = await fetch(url, { method: "HEAD" });
+  return response.ok;
+};


### PR DESCRIPTION
Closes #138 

This replaces the existing compile cache mechanism which is not ideal (see below).

In this PR, we maintain a simple cache in local storage that maps stan program hashes to main.js URLs (main.js is created during compilation). Each time the main.stan is saved (or on initial load), we check this cache to see if the URL exists (meaning that a job had already completed). On cache hit we still need to verify that the remote file exists (maybe the compilation server was restarted). If not exists, clear that entry from the cache. If it does exist, then we don't need to create a new job, we'll just use that. If this cache (which should be very small) ever gets to more than 50 entries, it is simply cleared to avoid out-of-space error.

EXISTING (non-ideal) functionality

Every time the page is reloaded, a new compilation job is created. There is a localStorage cache but it doesn't point to the main.js URL, but just keeps track about whether the program has been compiled. There are a number of problems with this strategy (I know, I coded it in the first place), and I won't take the time to enumerate all the negatives (unless prompted).