### PR TITLE
Add overflow-x hidden to .Sidebar

### DIFF
--- a/gui/src/localStyles.css
+++ b/gui/src/localStyles.css
@@ -62,6 +62,10 @@
 }
 
 /* Sidebar */
+.Sidebar {
+  overflow-x: hidden;
+}
+
 .Sidebar h3 {
   padding: 0px;
   margin-left: 12px;


### PR DESCRIPTION
Closes #183 

As @WardBrian mentioned, adding overflow-x: hidden to .Sidebar does the trick.

It would be better to fix this in a different way (dealing with margins), but it seems that the problem is hidden in MUI, and difficult to troubleshoot.