### PR TITLE
Move server choice state up for better consistency

### DIFF
--- a/gui/src/app/CompilationServerConnectionControl/CompilationServerConnectionControl.tsx
+++ b/gui/src/app/CompilationServerConnectionControl/CompilationServerConnectionControl.tsx
@@ -11,6 +11,8 @@ import Typography from "@mui/material/Typography";
 export const publicUrl = "https://trom-stan-wasm-server.magland.org";
 export const localUrl = "http://localhost:8083";
 
+export type ServerType = "public" | "local" | "custom";
+
 type CompilationServerConnectionControlProps = {
   // none
 };
@@ -21,6 +23,15 @@ const CompilationServerConnectionControl: FunctionComponent<
   const [stanWasmServerUrl, setStanWasmServerUrl] = useState<string>(
     localStorage.getItem("stanWasmServerUrl") || publicUrl,
   );
+
+  const [serverType, setServerType] = useState<ServerType>(
+    stanWasmServerUrl === publicUrl
+      ? "public"
+      : stanWasmServerUrl === localUrl
+        ? "local"
+        : "custom",
+  );
+
   const { isConnected, retryConnection } = useIsConnected(stanWasmServerUrl);
   useEffect(() => {
     localStorage.setItem("stanWasmServerUrl", stanWasmServerUrl);
@@ -36,12 +47,6 @@ const CompilationServerConnectionControl: FunctionComponent<
     retryConnection();
   }, [retryConnection]);
 
-  const serverLabel =
-    stanWasmServerUrl === publicUrl
-      ? "public"
-      : stanWasmServerUrl === localUrl
-        ? "local"
-        : "custom";
   return (
     <>
       <IconButton onClick={openDialog} color="inherit" size="small">
@@ -53,7 +58,7 @@ const CompilationServerConnectionControl: FunctionComponent<
         &nbsp;
         <Typography color="white" fontSize={12}>
           {isConnected ? "connected to " : "not connected to "}
-          {serverLabel}
+          {serverType}
         </Typography>
       </IconButton>
       <CloseableDialog
@@ -67,6 +72,8 @@ const CompilationServerConnectionControl: FunctionComponent<
           setStanWasmServerUrl={setStanWasmServerUrl}
           isConnected={isConnected}
           onRetry={handleRetry}
+          choice={serverType}
+          setChoice={setServerType}
         />
       </CloseableDialog>
     </>

--- a/gui/src/app/CompilationServerConnectionControl/ConfigureCompilationServerDialog.tsx
+++ b/gui/src/app/CompilationServerConnectionControl/ConfigureCompilationServerDialog.tsx
@@ -1,5 +1,9 @@
-import { FunctionComponent, useCallback, useState } from "react";
-import { localUrl, publicUrl } from "./CompilationServerConnectionControl";
+import { FunctionComponent, useCallback } from "react";
+import {
+  localUrl,
+  publicUrl,
+  ServerType,
+} from "./CompilationServerConnectionControl";
 import FormControl from "@mui/material/FormControl";
 import Divider from "@mui/material/Divider";
 import FormLabel from "@mui/material/FormLabel";
@@ -10,20 +14,25 @@ import TextField from "@mui/material/TextField";
 import IconButton from "@mui/material/IconButton";
 import { Refresh } from "@mui/icons-material";
 
-type ServerType = "public" | "local" | "custom";
-
 type ConfigureCompilationServerDialogProps = {
   stanWasmServerUrl: string;
   setStanWasmServerUrl: (url: string) => void;
   isConnected: boolean;
   onRetry: () => void;
+  choice: ServerType;
+  setChoice: (choice: ServerType) => void;
 };
 
 const ConfigureCompilationServerDialog: FunctionComponent<
   ConfigureCompilationServerDialogProps
-> = ({ stanWasmServerUrl, setStanWasmServerUrl, isConnected, onRetry }) => {
-  const [choice, setChoice] = useState<ServerType>("public");
-
+> = ({
+  stanWasmServerUrl,
+  setStanWasmServerUrl,
+  isConnected,
+  onRetry,
+  choice,
+  setChoice,
+}) => {
   const makeChoice = useCallback(
     (_: unknown, choice: string) => {
       if (choice === "public") {
@@ -37,7 +46,7 @@ const ConfigureCompilationServerDialog: FunctionComponent<
       }
       setChoice(choice);
     },
-    [setStanWasmServerUrl],
+    [setChoice, setStanWasmServerUrl],
   );
 
   return (


### PR DESCRIPTION
Follow on to #180, this moves the state up a bit which gives us a more consistent behavior when you refresh the page and then click on the control pop-up (previously, the radio button would always initialize to "Public", even if that is not what the page was actually storing).