### PR TITLE
Style scrollbar in chrome

### DIFF
--- a/gui/src/app/Scripting/OutputDivUtils.tsx
+++ b/gui/src/app/Scripting/OutputDivUtils.tsx
@@ -9,11 +9,10 @@ export const writeConsoleOutToDiv = (
 ) => {
   if (x === "") return;
   if (!parentDiv.current) return;
-  const styleClass = type === "stdout" ? "WorkerStdout" : "WorkerStderr";
   const preElement = document.createElement("pre");
   preElement.textContent = x;
   const divElement = document.createElement("div");
-  divElement.className = styleClass;
+  divElement.className = type;
   divElement.appendChild(preElement);
   parentDiv.current.appendChild(divElement);
 };

--- a/gui/src/index.css
+++ b/gui/src/index.css
@@ -4,20 +4,32 @@ body {
   min-height: 100vh;
 }
 
-.WorkerStdout {
-  color: darkblue;
+@supports (scrollbar-width: auto) {
+  body {
+    scrollbar-width: thin;
+  }
 }
 
-.WorkerStdout pre {
-  margin: 0px;
-  padding: 1px;
-}
+@supports selector(::-webkit-scrollbar) {
+  ::-webkit-scrollbar {
+    width: 3px;
+    height: 3px;
+  }
 
-.WorkerStderr {
-  color: red;
-}
+  :hover::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
 
-.WorkerStderr pre {
-  margin: 0px;
-  padding: 1px;
+  ::-webkit-scrollbar-track {
+    background: #f2f2f2;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background: #bdbdbd;
+  }
+
+  ::-webkit-scrollbar-thumb:hover {
+    background: #6e6e6e;
+  }
 }

--- a/gui/src/localStyles.css
+++ b/gui/src/localStyles.css
@@ -27,6 +27,24 @@
   white-space: pre-wrap;
 }
 
+.stdout {
+  color: darkblue;
+}
+
+.stdout pre {
+  margin: 0px;
+  padding: 1px;
+}
+
+.stderr {
+  color: red;
+}
+
+.stderr pre {
+  margin: 0px;
+  padding: 1px;
+}
+
 /* Compilation Results (StanCompileResultWindow) */
 .ErrorsWindow {
   height: 100%;


### PR DESCRIPTION
Closes #199 ?

This adds some CSS to style the scrollbar in Chrome to make it look more like firefox. Firefox seems to ignore these selectors and keep the minimal scroll bar no matter what:

![image](https://github.com/user-attachments/assets/d99b1a4b-7e8d-4fc7-b641-5ea4f4cadd3e)

When hovered:
![image](https://github.com/user-attachments/assets/ea6ca60c-6571-4be3-ad20-7027c943e6cc)


Here is Firefox (before or after this PR)

![image](https://github.com/user-attachments/assets/43232e5f-1e32-47b7-92d3-b6499c019175)

When covered
![image](https://github.com/user-attachments/assets/afbaddbb-abec-486e-bbde-f082ce2a3689)
