### PR TITLE
Improve formatting of draws table

### DIFF
--- a/gui/src/app/SamplerOutputView/SamplerOutputView.tsx
+++ b/gui/src/app/SamplerOutputView/SamplerOutputView.tsx
@@ -174,7 +174,7 @@ const DrawsView: FunctionComponent<DrawsViewProps> = ({
               <td>{drawChainIds[i]}</td>
               <td>{drawNumbers[i]}</td>
               {draws.map((draw, j) => (
-                <td key={j}>{draw[i]}</td>
+                <td key={j}>{draw[i].toPrecision(6)}</td>
               ))}
             </tr>
           ))}

--- a/gui/src/app/SamplerOutputView/SamplerOutputView.tsx
+++ b/gui/src/app/SamplerOutputView/SamplerOutputView.tsx
@@ -108,7 +108,9 @@ const DrawsView: FunctionComponent<DrawsViewProps> = ({
   >(300);
   const draws2 = useMemo(() => {
     if (abbreviatedToNumRows === undefined) return draws;
-    return draws.map((draw) => draw.slice(0, abbreviatedToNumRows));
+    return draws.map((draw) =>
+      formatDraws(draw.slice(0, abbreviatedToNumRows)),
+    );
   }, [draws, abbreviatedToNumRows]);
   const handleExportToCsv = useCallback(() => {
     const csvText = prepareCsvText(
@@ -173,8 +175,8 @@ const DrawsView: FunctionComponent<DrawsViewProps> = ({
             <tr key={i}>
               <td>{drawChainIds[i]}</td>
               <td>{drawNumbers[i]}</td>
-              {draws.map((draw, j) => (
-                <td key={j}>{draw[i].toPrecision(6)}</td>
+              {draws2.map((draw, j) => (
+                <td key={j}>{draw[i]}</td>
               ))}
             </tr>
           ))}
@@ -194,6 +196,11 @@ const DrawsView: FunctionComponent<DrawsViewProps> = ({
         )}
     </div>
   );
+};
+
+const formatDraws = (draws: number[]) => {
+  if (draws.every((x) => Number.isInteger(x))) return draws;
+  return draws.map((x) => x.toPrecision(6));
 };
 
 const prepareCsvText = (

--- a/gui/src/draws-table.css
+++ b/gui/src/draws-table.css
@@ -22,6 +22,7 @@
 .draws-table th,
 .draws-table td {
   padding: 2px 2px;
+  white-space: nowrap;
 }
 
 .draws-table tbody tr {


### PR DESCRIPTION
This rounds to 6 digits and makes it so that resizing the tab doesn't lead to very skinny columns that wrap.

Before:
![image](https://github.com/user-attachments/assets/9de749f0-539b-41e6-9829-8f74ee245061)


After:
![image](https://github.com/user-attachments/assets/3b177540-ee91-4473-93b5-9990e630244b)
