### PR TITLE
Clean up compilation error handling

### DIFF
--- a/gui/src/app/CompilationServerConnectionControl/ConfigureCompilationServerDialog.tsx
+++ b/gui/src/app/CompilationServerConnectionControl/ConfigureCompilationServerDialog.tsx
@@ -87,15 +87,15 @@ const ConfigureCompilationServerDialog: FunctionComponent<
 
         {serverType === "custom" && (
           <div>
-            <p>
-              <TextField
-                variant="standard"
-                label="Custom server URL"
-                disabled={serverType !== "custom"}
-                value={stanWasmServerUrl}
-                onChange={(e) => setStanWasmServerUrl(e.target.value)}
-              />
-            </p>
+            <TextField
+              variant="standard"
+              label="Custom server URL"
+              disabled={serverType !== "custom"}
+              value={stanWasmServerUrl}
+              onChange={(e) => setStanWasmServerUrl(e.target.value)}
+            />
+            <br />
+            <br />
           </div>
         )}
       </FormControl>

--- a/gui/src/app/CompileContext/CompileContextProvider.tsx
+++ b/gui/src/app/CompileContext/CompileContextProvider.tsx
@@ -69,13 +69,13 @@ export const CompileContextProvider: FunctionComponent<
       onStatus,
     );
 
+    setTheStanFileContentThasHasBeenCompiled(data.stanFileContent);
     if (!mainJsUrl) {
       setCompileStatus("failed");
       return;
     }
     setCompiledMainJsUrl(mainJsUrl);
     setCompileStatus("compiled");
-    setTheStanFileContentThasHasBeenCompiled(data.stanFileContent);
   }, [
     data.stanFileContent,
     setCompiledMainJsUrl,

--- a/gui/src/app/CompileContext/compileStanProgram.ts
+++ b/gui/src/app/CompileContext/compileStanProgram.ts
@@ -5,6 +5,11 @@ const compileStanProgram = async (
   stanProgram: string,
   onStatus: (s: string) => void,
 ): Promise<{ mainJsUrl?: string }> => {
+  const setStatusAndWarn = (msg: string) => {
+    onStatus(msg);
+    console.warn(msg);
+  };
+
   try {
     onStatus("checking cache");
     const downloadMainJsUrlFromCache = await checkMainJsUrlCache(
@@ -27,13 +32,15 @@ const compileStanProgram = async (
       },
     });
     if (!initiation.ok) {
-      onStatus(`failed to initiate job: ${await messageOrStatus(initiation)}`);
+      setStatusAndWarn(
+        `failed to initiate job: ${await messageOrStatus(initiation)}`,
+      );
       return {};
     }
     const resp = await initiation.json();
     const job_id = resp.job_id;
     if (!job_id) {
-      onStatus(`failed to initiate job: ${JSON.stringify(resp)}`);
+      setStatusAndWarn(`failed to initiate job: ${JSON.stringify(resp)}`);
       return {};
     }
 
@@ -47,7 +54,9 @@ const compileStanProgram = async (
       body: stanProgram,
     });
     if (!upload.ok) {
-      onStatus(`failed to upload file: ${await messageOrStatus(upload)}`);
+      setStatusAndWarn(
+        `failed to upload file: ${await messageOrStatus(upload)}`,
+      );
       return {};
     }
     onStatus("file uploaded successfully");
@@ -61,7 +70,9 @@ const compileStanProgram = async (
       },
     });
     if (!runCompile.ok) {
-      onStatus(`failed to compile: ${await messageOrStatus(runCompile)}`);
+      setStatusAndWarn(
+        `failed to compile: ${await messageOrStatus(runCompile)}`,
+      );
       return {};
     }
 
@@ -73,7 +84,7 @@ const compileStanProgram = async (
     onStatus("Checking download of main.js");
     const downloadCheck = await fetch(mainJsUrl);
     if (!downloadCheck.ok) {
-      onStatus(
+      setStatusAndWarn(
         `failed to download main.js: ${await messageOrStatus(downloadCheck)}`,
       );
       return {};
@@ -82,7 +93,7 @@ const compileStanProgram = async (
     onStatus("compiled");
     return { mainJsUrl };
   } catch (e) {
-    onStatus(`failed to compile: ${e}`);
+    setStatusAndWarn(`failed to compile: ${e}`);
     return {};
   }
 };

--- a/gui/src/localStyles.css
+++ b/gui/src/localStyles.css
@@ -149,7 +149,7 @@ span.EditorToolbarItem {
   font-weight: normal;
   letter-spacing: normal;
   display: inline-block;
-  white-space: normal;
+  white-space: nowrap;
   padding-left: 5px;
   font-size: 14px;
 }


### PR DESCRIPTION
This fixes an issue where the error is immediately removed from the UI, and also cleans up compileStanProgram.ts to show the more appropriate error message we attach to the http response if it is present. 

I noticed yesterday the compilation server window was raising a warning about a `div` inside `<p>`, so this fixes that as well.


The easiest way to test this PR is to edit the backend server so it returns a bad response. I choice to make `_stan_src_file_is_within_size_limit` unconditionally return False to test.