### PR TITLE
Add basic color theming, ability to toggle light/dark

### DIFF
--- a/gui/src/app/App.tsx
+++ b/gui/src/app/App.tsx
@@ -1,19 +1,14 @@
-import createTheme from "@mui/material/styles/createTheme";
-import { ThemeProvider } from "@mui/material/styles";
-import CssBaseline from "@mui/material/CssBaseline";
+import ToggleableThemeProvider from "./ToggleableThemeProvider";
 import ProjectContextProvider from "@SpCore/ProjectContextProvider";
 import HomePage from "@SpPages/HomePage";
 import { Analytics } from "@vercel/analytics/react";
 import { BrowserRouter } from "react-router-dom";
 import { CompileContextProvider } from "./CompileContext/CompileContextProvider";
 
-const theme = createTheme();
-
-function App() {
+const App = () => {
   return (
     <BrowserRouter>
-      <ThemeProvider theme={theme}>
-        <CssBaseline />
+      <ToggleableThemeProvider>
         <div className="MainWindow">
           <ProjectContextProvider>
             <CompileContextProvider>
@@ -22,9 +17,9 @@ function App() {
           </ProjectContextProvider>
           <Analytics />
         </div>
-      </ThemeProvider>
+      </ToggleableThemeProvider>
     </BrowserRouter>
   );
-}
+};
 
 export default App;

--- a/gui/src/app/ToggleableThemeProvider.tsx
+++ b/gui/src/app/ToggleableThemeProvider.tsx
@@ -1,0 +1,69 @@
+import { createTheme, ThemeProvider } from "@mui/material/styles";
+import CssBaseline from "@mui/material/CssBaseline";
+import useMediaQuery from "@mui/material/useMediaQuery";
+import {
+  createContext,
+  FunctionComponent,
+  PropsWithChildren,
+  useCallback,
+  useMemo,
+  useState,
+} from "react";
+
+export const LightDarkContext = createContext({ toggleMode: () => {} });
+
+const colorPalette = {
+  primary: {
+    main: "#E16D44",
+  },
+  secondary: {
+    main: "#44B8E1",
+  },
+} as const;
+
+const storedTheme = localStorage.getItem("theme") as "dark" | "light" | null;
+
+const ToggleableThemeProvider: FunctionComponent<PropsWithChildren> = ({
+  children,
+}) => {
+  const prefersDarkMode = useMediaQuery("(prefers-color-scheme: dark)");
+
+  const defaultTheme = useMemo(() => {
+    if (storedTheme) {
+      return storedTheme;
+    }
+    if (prefersDarkMode) {
+      return "dark";
+    }
+    return "light";
+  }, [prefersDarkMode]);
+
+  const [mode, setMode] = useState<"light" | "dark">(defaultTheme);
+
+  const theme = useMemo(
+    () =>
+      createTheme({
+        palette: { ...colorPalette, mode },
+      }),
+    [mode],
+  );
+
+  const toggleMode = useCallback(() => {
+    setMode((prev) => {
+      const newTheme = prev === "light" ? "dark" : "light";
+      localStorage.setItem("theme", newTheme);
+      return newTheme;
+    });
+  }, []);
+
+  return (
+    <LightDarkContext.Provider value={{ toggleMode }}>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        {children}
+      </ThemeProvider>
+    </LightDarkContext.Provider>
+  );
+};
+
+export default ToggleableThemeProvider;

--- a/gui/src/app/components/StyledTables.tsx
+++ b/gui/src/app/components/StyledTables.tsx
@@ -12,6 +12,8 @@ export const SecondaryColoredTableHead = styled(TableHead)(({ theme }) => ({
   backgroundColor: theme.palette.secondary.light,
   th: {
     color: theme.palette.secondary.contrastText,
+    whiteSpace: "nowrap",
+    paddingRight: "0.5rem",
   },
 }));
 
@@ -19,6 +21,8 @@ export const SuccessColoredTableHead = styled(TableHead)(({ theme }) => ({
   backgroundColor: theme.palette.success.light,
   th: {
     color: theme.palette.success.contrastText,
+    whiteSpace: "nowrap",
+    paddingRight: "0.5rem",
   },
 }));
 

--- a/gui/src/app/pages/HomePage/TopBar.tsx
+++ b/gui/src/app/pages/HomePage/TopBar.tsx
@@ -1,10 +1,11 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import CompilationServerConnectionControl from "@SpStanc/CompilationServerConnectionControl";
-import { Menu, QuestionMark } from "@mui/icons-material";
+import { Brightness7, DarkMode, Menu, QuestionMark } from "@mui/icons-material";
 import AppBar from "@mui/material/AppBar";
 import IconButton from "@mui/material/IconButton";
 import Toolbar from "@mui/material/Toolbar";
-import { FunctionComponent } from "react";
+import { useTheme } from "@mui/material/styles";
+import { LightDarkContext } from "app/ToggleableThemeProvider";
+import { FunctionComponent, useContext } from "react";
 
 type TopBarProps = {
   title: string;
@@ -12,6 +13,10 @@ type TopBarProps = {
 };
 
 const TopBar: FunctionComponent<TopBarProps> = ({ title, onSetCollapsed }) => {
+  const theme = useTheme();
+  const isLight = theme.palette.mode === "light";
+  const { toggleMode } = useContext(LightDarkContext);
+
   return (
     <AppBar
       position="sticky"
@@ -33,6 +38,13 @@ const TopBar: FunctionComponent<TopBarProps> = ({ title, onSetCollapsed }) => {
         </IconButton>
         Stan Playground - {title}
         <span className="TopBarSpacer" />
+        <IconButton title="Toggle light/dark" size="small" onClick={toggleMode}>
+          {isLight ? (
+            <DarkMode fontSize="inherit" htmlColor="white" />
+          ) : (
+            <Brightness7 fontSize="inherit" />
+          )}
+        </IconButton>
         <CompilationServerConnectionControl />
         <IconButton
           title="About Stan Playground"


### PR DESCRIPTION
This uses the orange from the logo proposal we've been discussing as the primary color and its complementary color as the secondary. 


The main contribution is the button which toggles between light/dark.

![image](https://github.com/user-attachments/assets/0502ad37-f54a-4cd7-9252-fb46c34d4532)

![image](https://github.com/user-attachments/assets/978c77d1-d773-4a46-8c15-5b9ee3b3b17d)

There are definitely items we will want to tweak the appearance of still, but I think this closes #186 
