### PR TITLE
Add missing case for loading analysis.R, exhaustiveness checks

### DIFF
--- a/gui/src/app/FileEditor/TextEditor.tsx
+++ b/gui/src/app/FileEditor/TextEditor.tsx
@@ -85,7 +85,7 @@ const TextEditor: FunctionComponent<Props> = ({
 
     const modelMarkers = codeMarkers.map((marker) => ({
       ...marker,
-      severity: toMonacoMarkerSeverity(marker.severity),
+      severity: toMonacoMarkerSeverity[marker.severity],
     }));
 
     monacoInstance.editor.setModelMarkers(
@@ -173,20 +173,12 @@ const TextEditor: FunctionComponent<Props> = ({
   );
 };
 
-const toMonacoMarkerSeverity = (
-  s: "error" | "warning" | "hint" | "info",
-): MarkerSeverity => {
-  switch (s) {
-    case "error":
-      return MarkerSeverity.Error;
-    case "warning":
-      return MarkerSeverity.Warning;
-    case "hint":
-      return MarkerSeverity.Hint;
-    case "info":
-      return MarkerSeverity.Info;
-  }
-};
+const toMonacoMarkerSeverity = {
+  error: MarkerSeverity.Error,
+  warning: MarkerSeverity.Warning,
+  hint: MarkerSeverity.Hint,
+  info: MarkerSeverity.Info,
+} as const;
 
 const createHintTextContentWidget = (content: string | HTMLSpanElement) => {
   return {

--- a/gui/src/app/Project/FileMapping.ts
+++ b/gui/src/app/Project/FileMapping.ts
@@ -3,6 +3,7 @@ import {
   ProjectPersistentDataModel,
   stringifyField,
 } from "@SpCore/ProjectDataModel";
+import { unreachable } from "@SpUtil/unreachable";
 
 // This code exists to provide rigorous definitions for the mappings between
 // the in-memory representation of a Stan Playground project (i.e. the
@@ -29,6 +30,10 @@ export enum FileNames {
   DATAPYFILE = "data.py",
   DATARFILE = "data.R",
 }
+
+const isFileName = (x: any): x is FileNames => {
+  return Object.values(FileNames).includes(x);
+};
 
 // FileMapType enforces an exhaustive mapping from data-model fields to the
 // known file names that store those fields. (This is the 1-2 leg of the
@@ -94,7 +99,11 @@ export const mapFileContentsToModel = (
 ): Partial<FieldsContentsMap> => {
   const fields = Object.keys(files);
   const theMap: Partial<FieldsContentsMap> = {};
+
   fields.forEach((f) => {
+    // Don't do anything for unrecognized filenames
+    if (!isFileName(f)) return;
+
     switch (f) {
       case FileNames.META: {
         theMap.meta = files[f];
@@ -112,6 +121,10 @@ export const mapFileContentsToModel = (
         theMap.analysisPyFileContent = files[f];
         break;
       }
+      case FileNames.ANALYSISRFILE: {
+        theMap.analysisRFileContent = files[f];
+        break;
+      }
       case FileNames.DATAPYFILE: {
         theMap.dataPyFileContent = files[f];
         break;
@@ -125,8 +138,7 @@ export const mapFileContentsToModel = (
         break;
       }
       default:
-        // Don't do anything for unrecognized filenames
-        break;
+        unreachable(f);
     }
   });
   return theMap;

--- a/gui/src/app/Project/ProjectReducer.ts
+++ b/gui/src/app/Project/ProjectReducer.ts
@@ -6,6 +6,7 @@ import {
   SamplingOpts,
 } from "@SpCore/ProjectDataModel";
 import { loadFromProjectFiles } from "@SpCore/ProjectSerialization";
+import { unreachable } from "@SpUtil/unreachable";
 import { Reducer } from "react";
 
 export type ProjectReducerType = Reducer<
@@ -80,6 +81,8 @@ const ProjectReducer = (s: ProjectDataModel, a: ProjectReducerAction) => {
     case "clear": {
       return initialDataModel;
     }
+    default:
+      unreachable(a);
   }
 };
 

--- a/gui/src/app/Project/ProjectReducer.ts
+++ b/gui/src/app/Project/ProjectReducer.ts
@@ -82,7 +82,7 @@ const ProjectReducer = (s: ProjectDataModel, a: ProjectReducerAction) => {
       return initialDataModel;
     }
     default:
-      unreachable(a);
+      return unreachable(a);
   }
 };
 

--- a/gui/src/app/SamplingOptsPanel/SamplingOptsPanel.tsx
+++ b/gui/src/app/SamplingOptsPanel/SamplingOptsPanel.tsx
@@ -1,6 +1,7 @@
 import Grid from "@mui/material/Grid";
 import Link from "@mui/material/Link";
 import { defaultSamplingOpts, SamplingOpts } from "@SpCore/ProjectDataModel";
+import { unreachable } from "@SpUtil/unreachable";
 import { FunctionComponent, useCallback } from "react";
 
 type SamplingOptsPanelProps = {
@@ -212,6 +213,8 @@ const NumberEdit: FunctionComponent<NumberEditProps> = ({
           newValue = undefined;
         }
         break;
+      default:
+        unreachable(type);
     }
     onChange(newValue);
   };

--- a/gui/src/app/StanSampler/StanModelWorker.ts
+++ b/gui/src/app/StanSampler/StanModelWorker.ts
@@ -1,3 +1,4 @@
+import { unreachable } from "@SpUtil/unreachable";
 import StanModel from "tinystan";
 
 export enum Requests {
@@ -112,5 +113,7 @@ self.onmessage = (e) => {
       }
       break;
     }
+    default:
+      unreachable(purpose);
   }
 };

--- a/gui/src/app/StanSampler/StanSampler.ts
+++ b/gui/src/app/StanSampler/StanSampler.ts
@@ -3,6 +3,7 @@ import { Replies, Requests } from "@SpStanSampler/StanModelWorker";
 import StanWorkerUrl from "@SpStanSampler/StanModelWorker?worker&url";
 import type { SamplerParams } from "tinystan";
 import { type StanRunAction } from "./useStanSampler";
+import { unreachable } from "@SpUtil/unreachable";
 
 export type StanSamplerStatus =
   | ""
@@ -77,6 +78,8 @@ class StanSampler {
           }
           break;
         }
+        default:
+          unreachable(purpose);
       }
     };
     this.update({ type: "statusUpdate", status: "loading" });

--- a/gui/src/app/StanSampler/useStanSampler.ts
+++ b/gui/src/app/StanSampler/useStanSampler.ts
@@ -3,6 +3,7 @@ import { type Progress } from "@SpStanSampler/StanModelWorker";
 import StanSampler, {
   type StanSamplerStatus,
 } from "@SpStanSampler/StanSampler";
+import { unreachable } from "@SpUtil/unreachable";
 import { useEffect, useReducer, useState } from "react";
 
 export type StanRun = {
@@ -73,6 +74,8 @@ export const StanRunReducer = (
         paramNames: action.paramNames,
         computeTimeSec: action.computeTimeSec,
       };
+    default:
+      return unreachable(action);
   }
 };
 

--- a/gui/src/app/util/unreachable.ts
+++ b/gui/src/app/util/unreachable.ts
@@ -1,0 +1,5 @@
+// Helper function to check if a switch statement is exhaustive
+// By using the never type, we make TSC prove that all cases are handled
+export const unreachable = (_: never): never => {
+  throw Error("Unreachable code reached");
+};


### PR DESCRIPTION
Fixes a bug where analysis.R files were not being loaded properly.

This also adds some uses of the typescript `never` type to try to ensure we won't have similar "missing case in switch" bugs again