### PR TITLE
Resolve spurious 'unreachable code' errors

### DIFF
--- a/gui/src/app/Scripting/pyodide/pyodideWorker.ts
+++ b/gui/src/app/Scripting/pyodide/pyodideWorker.ts
@@ -1,4 +1,5 @@
 import { PyodideInterface, loadPyodide } from "pyodide";
+import { isMonacoWorkerNoise } from "@SpUtil/isMonacoWorkerNoise";
 import { InterpreterStatus } from "@SpScripting/InterpreterTypes";
 import {
   MessageFromPyodideWorker,
@@ -62,6 +63,9 @@ const addImage = (image: any) => {
 console.log("pyodide worker loaded");
 
 self.onmessage = async (e) => {
+  if (isMonacoWorkerNoise(e.data)) {
+    return;
+  }
   const message = e.data;
   await run(message.code, message.spData, message.spRunSettings);
 };

--- a/gui/src/app/Stanc/stancWorker.ts
+++ b/gui/src/app/Stanc/stancWorker.ts
@@ -5,6 +5,8 @@ import {
   StancWorkerRequests,
 } from "@SpStanc/Types";
 import rawStancJS from "@SpStanc/stanc.js?raw"; // https://vitejs.dev/guide/assets#importing-asset-as-string
+import { isMonacoWorkerNoise } from "@SpUtil/isMonacoWorkerNoise";
+import { unreachable } from "@SpUtil/unreachable";
 
 let stanc: undefined | StancFunction;
 try {
@@ -33,6 +35,10 @@ try {
 const postReply = (message: StancReplyMessage) => self.postMessage(message);
 
 self.onmessage = (e: MessageEvent<StancRequestMessage>) => {
+  if (isMonacoWorkerNoise(e.data)) {
+    return;
+  }
+
   const { purpose, name, code } = e.data;
 
   if (!stanc) {
@@ -61,5 +67,7 @@ self.onmessage = (e: MessageEvent<StancRequestMessage>) => {
       postReply({ errors, warnings });
       break;
     }
+    default:
+      unreachable(purpose);
   }
 };

--- a/gui/src/app/util/isMonacoWorkerNoise.ts
+++ b/gui/src/app/util/isMonacoWorkerNoise.ts
@@ -1,8 +1,7 @@
-// monaco-editor has a call to globalThis.postMessage with the '*' target
-// so our workers will recieve this message. We ignore it to prevent
-
 import baseObjectCheck from "./baseObjectCheck";
 
+// monaco-editor has a call to globalThis.postMessage with the '*' target
+// so our workers will recieve this message. We ignore it to prevent
 // anything weird from happening.
 export const isMonacoWorkerNoise = (obj: any): boolean =>
   !baseObjectCheck(obj) ||

--- a/gui/src/app/util/isMonacoWorkerNoise.ts
+++ b/gui/src/app/util/isMonacoWorkerNoise.ts
@@ -1,0 +1,9 @@
+// monaco-editor has a call to globalThis.postMessage with the '*' target
+// so our workers will recieve this message. We ignore it to prevent
+
+import baseObjectCheck from "./baseObjectCheck";
+
+// anything weird from happening.
+export const isMonacoWorkerNoise = (obj: any): boolean =>
+  !baseObjectCheck(obj) ||
+  Object.prototype.hasOwnProperty.call(obj, "vscodeScheduleAsyncWork");


### PR DESCRIPTION
After #211, there are `Uncaught Error: Unreachable code reached` messages in the console. 

After digging into these, it seems that some code from Monaco is sending a message to _all_ web workers with some regularity (`$globalThis.postMessage({ vscodeScheduleAsyncWork: myId }, '*');`)

This is breaking our assumption that we are the only ones sending messages, so it violates our type guarantees. This PR adds a simple filter for this message to our workers.

As part of debugging this, I wrote better types for the StanModelWorker, so I left those in as a extra value-add