### PR TITLE
Test query loading

### DIFF
--- a/gui/src/app/Project/ProjectDataModel.ts
+++ b/gui/src/app/Project/ProjectDataModel.ts
@@ -37,13 +37,15 @@ export const isSamplingOpts = (x: any): x is SamplingOpts => {
 
 const numSamplingOpts = Object.keys(defaultSamplingOpts).length;
 
-const validateSamplingOpts = (x: SamplingOpts): boolean => {
+export const validateSamplingOpts = (x: SamplingOpts): boolean => {
   const naturalFields = [x.num_chains, x.num_samples, x.num_warmup];
   const positiveFields = [x.num_chains, x.num_samples];
   const nonnegativeFields = [x.num_warmup, x.init_radius];
   if (naturalFields.some((f) => !Number.isInteger(f))) return false;
-  if (positiveFields.some((f) => f <= 0)) return false;
-  if (nonnegativeFields.some((f) => f < 0)) return false;
+  if (positiveFields.some((f) => !Number.isFinite(f) || f <= 0)) return false;
+  if (nonnegativeFields.some((f) => !Number.isFinite(f) || f < 0)) return false;
+
+  if (x.seed !== undefined && !Number.isInteger(x.seed)) return false;
 
   if (Object.keys(x).length !== numSamplingOpts) return false;
   return true;

--- a/gui/src/app/util/deepCopy.ts
+++ b/gui/src/app/util/deepCopy.ts
@@ -1,3 +1,0 @@
-export const deepCopy = (obj: any) => {
-  return JSON.parse(JSON.stringify(obj));
-};

--- a/gui/test/app/Project/ProjectQueryLoading.test.ts
+++ b/gui/test/app/Project/ProjectQueryLoading.test.ts
@@ -272,7 +272,7 @@ describe("Query fetching", () => {
       );
     });
 
-    test("fetchRemoteProject errors on when gist retrieval fails", async () => {
+    test("fetchRemoteProject errors when gist retrieval fails", async () => {
       const queryParam = new URLSearchParams(
         "project=https://gist.github.com/test/bad",
       );

--- a/gui/vite.config.ts
+++ b/gui/vite.config.ts
@@ -17,11 +17,8 @@ export default defineConfig({
     },
   },
   test: {
-    // note for testing: mockReset clears all spies/mocks and resets to empty function,
-    // while restoreMocks: true calls .mockRestore() thereby clearing spies & mock
-    // history and resets implementation to origina implementation.
     // Consider logHeapUsage flag to diagnose memory leaks.
-    mockReset: true,
+    clearMocks: true,
     coverage: {
       enabled: true,
       exclude: [


### PR DESCRIPTION
This gets us up to 100% coverage on `ProjectQueryLoading.ts`

This did dig up a couple issues:

- we were never validating that the sampling options provided piece-by-piece were valid
- `JSON.stringify` does not preserve `undefine`s, so our deepCopy implementation subtly was broken
- There were a few cases where we never indicated a problem to the user