### PR TITLE
Prevent running of model with non-parseable data.json.

### DIFF
--- a/gui/src/app/RunPanel/CompiledRunPanel.tsx
+++ b/gui/src/app/RunPanel/CompiledRunPanel.tsx
@@ -2,8 +2,9 @@ import Box from "@mui/material/Box";
 import LinearProgress, {
   LinearProgressProps,
 } from "@mui/material/LinearProgress";
+import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
-import { FunctionComponent } from "react";
+import { FunctionComponent, useMemo } from "react";
 
 import Button from "@mui/material/Button";
 import { SamplingOpts } from "@SpCore/ProjectDataModel";
@@ -11,7 +12,7 @@ import { Progress } from "@SpStanSampler/StanModelWorker";
 import { StanSamplerStatus } from "@SpStanSampler/StanSampler";
 
 type CompiledRunPanelProps = {
-  handleRun: () => Promise<void>;
+  handleRun: undefined | (() => Promise<void>);
   cancelRun: () => void;
   runStatus: StanSamplerStatus;
   progress: Progress | undefined;
@@ -72,16 +73,29 @@ const CompiledRunPanel: FunctionComponent<CompiledRunPanelProps> = ({
     </div>
   );
 
+  const tooltip = useMemo(() => {
+    if (handleRun === undefined) return "Data must be validly formatted JSON";
+    return "Run sampling";
+  }, [handleRun]);
+
   return (
     <div>
-      <Button
-        variant="contained"
-        color="success"
-        onClick={handleRun}
-        disabled={runStatus === "sampling" || runStatus === "loading"}
-      >
-        run sampling
-      </Button>
+      <Tooltip title={tooltip}>
+        <span>
+          <Button
+            variant="contained"
+            color="success"
+            onClick={handleRun}
+            disabled={
+              runStatus === "sampling" ||
+              runStatus === "loading" ||
+              handleRun === undefined
+            }
+          >
+            run sampling
+          </Button>
+        </span>
+      </Tooltip>
       &nbsp;
       {runStatus === "loading" ? (
         loadingDiv

--- a/gui/src/app/RunPanel/CompiledRunPanel.tsx
+++ b/gui/src/app/RunPanel/CompiledRunPanel.tsx
@@ -75,8 +75,9 @@ const CompiledRunPanel: FunctionComponent<CompiledRunPanelProps> = ({
 
   const tooltip = useMemo(() => {
     if (handleRun === undefined) return "Data must be validly formatted JSON";
+    if (runStatus === "sampling") return "Sampling is in progress";
     return "Run sampling";
-  }, [handleRun]);
+  }, [handleRun, runStatus]);
 
   return (
     <div>

--- a/gui/src/app/RunPanel/CompiledRunPanel.tsx
+++ b/gui/src/app/RunPanel/CompiledRunPanel.tsx
@@ -76,6 +76,7 @@ const CompiledRunPanel: FunctionComponent<CompiledRunPanelProps> = ({
   const tooltip = useMemo(() => {
     if (handleRun === undefined) return "Data must be validly formatted JSON";
     if (runStatus === "sampling") return "Sampling is in progress";
+    if (runStatus === "loading") return "Model is currently loading";
     return "Run sampling";
   }, [handleRun, runStatus]);
 

--- a/gui/src/app/RunPanel/RunPanel.tsx
+++ b/gui/src/app/RunPanel/RunPanel.tsx
@@ -2,14 +2,14 @@
 import { FunctionComponent, useCallback, useContext, useMemo } from "react";
 
 import Button from "@mui/material/Button";
+import CircularProgress from "@mui/material/CircularProgress";
+import Tooltip from "@mui/material/Tooltip";
 import { CompileContext } from "@SpCompilation/CompileContext";
 import { ProjectContext } from "@SpCore/ProjectContextProvider";
 import { SamplingOpts, modelHasUnsavedChanges } from "@SpCore/ProjectDataModel";
 import StanSampler from "@SpStanSampler/StanSampler";
 import { StanRun } from "@SpStanSampler/useStanSampler";
 import CompiledRunPanel from "./CompiledRunPanel";
-import CircularProgress from "@mui/material/CircularProgress";
-import Tooltip from "@mui/material/Tooltip";
 
 type RunPanelProps = {
   sampler?: StanSampler;
@@ -32,6 +32,11 @@ const RunPanel: FunctionComponent<RunPanelProps> = ({
     if (!sampler) return;
     sampler.sample(data, samplingOpts);
   }, [sampler, data, samplingOpts]);
+
+  const possiblyHandleRun = useMemo(() => {
+    if (data === undefined) return undefined;
+    return handleRun;
+  }, [data, handleRun])
 
   const cancelRun = useCallback(() => {
     if (!sampler) return;
@@ -82,7 +87,7 @@ const RunPanel: FunctionComponent<RunPanelProps> = ({
       <div className="RunPanelPadded">
         {compileStatus === "compiled" ? (
           <CompiledRunPanel
-            handleRun={handleRun}
+            handleRun={possiblyHandleRun}
             cancelRun={cancelRun}
             runStatus={runStatus}
             progress={progress}


### PR DESCRIPTION
Fix #226.

This PR makes the `handleRun` callback (defined in `RunPanel.tsx` and used as a parameter to the `CompiledRunPanel` component) nullable. The callback will be `undefined` if the `data.json` does not parse successfully.

In turn, in the `CompiledRunPanel` component, the `Run Sampling` button will be disabled if the `handleRun` parameter is `undefined`. This prevents a downstream error in model execution caused by the failed parse.

I've added a tooltip to the "Run sampling" button that explains to the user why it is disabled in the data-did-not-parse case, and describes the function in the success case. (I also covered the cases where the model is loading or sampling is already in progress.