### PR TITLE
Make the default tab 2-spaces

### DIFF
--- a/gui/src/app/FileEditor/TextEditor.tsx
+++ b/gui/src/app/FileEditor/TextEditor.tsx
@@ -165,6 +165,7 @@ const TextEditor: FunctionComponent<Props> = ({
           domReadOnly: readOnly,
           wordWrap: "on",
           minimap: { enabled: false },
+          tabSize: 2,
         }}
         theme={theme}
       />


### PR DESCRIPTION
This aligns with what the auto-formatter's behavior is. A power user can still change it by pressing `F1` to pull up the monaco command pallet. 