### PR TITLE
Allow analysis scripts to read data.json

### DIFF
--- a/gui/src/app/Scripting/Analysis/AnalysisPyWindow.tsx
+++ b/gui/src/app/Scripting/Analysis/AnalysisPyWindow.tsx
@@ -34,6 +34,7 @@ const AnalysisPyWindow: FunctionComponent<AnalysisWindowProps> = ({
     onStatus,
     runnable,
     notRunnableReason,
+    files,
   } = useAnalysisState(latestRun);
 
   const callbacks = useMemo(
@@ -51,13 +52,18 @@ const AnalysisPyWindow: FunctionComponent<AnalysisWindowProps> = ({
   const handleRun = useCallback(
     (code: string) => {
       clearOutputDivs(consoleRef, imagesRef);
-      run(code, spData, {
-        loadsDraws: true,
-        showsPlots: true,
-        producesData: false,
+      run({
+        code,
+        spData,
+        spRunSettings: {
+          loadsDraws: true,
+          showsPlots: true,
+          producesData: false,
+        },
+        files,
       });
     },
-    [consoleRef, imagesRef, run, spData],
+    [consoleRef, imagesRef, run, spData, files],
   );
 
   const contentOnEmpty = useTemplatedFillerText(

--- a/gui/src/app/Scripting/Analysis/AnalysisRWindow.tsx
+++ b/gui/src/app/Scripting/Analysis/AnalysisRWindow.tsx
@@ -26,16 +26,18 @@ const AnalysisRWindow: FunctionComponent<AnalysisWindowProps> = ({
     onStatus,
     runnable,
     notRunnableReason,
+    files,
   } = useAnalysisState(latestRun);
 
   const { run } = useWebR({ consoleRef, imagesRef, onStatus });
+
   const handleRun = useCallback(
     async (userCode: string) => {
       clearOutputDivs(consoleRef, imagesRef);
       const code = loadDrawsCode + userCode;
-      await run({ code, spData });
+      await run({ code, spData, files });
     },
-    [consoleRef, imagesRef, run, spData],
+    [consoleRef, imagesRef, run, spData, files],
   );
 
   const contentOnEmpty = useTemplatedFillerText(

--- a/gui/src/app/Scripting/Analysis/analysis_template.R
+++ b/gui/src/app/Scripting/Analysis/analysis_template.R
@@ -5,3 +5,7 @@ install.packages("bayesplot")
 library(bayesplot)
 
 mcmc_hist(draws, pars = c("lp__"))
+
+# can also access data.json
+data <- jsonlite::read_json("./data.json")
+data

--- a/gui/src/app/Scripting/Analysis/analysis_template.py
+++ b/gui/src/app/Scripting/Analysis/analysis_template.py
@@ -12,3 +12,10 @@ print(samples.shape)
 plt.hist(samples.ravel(), bins=30)
 plt.title("lp__")
 plt.show()
+
+# you can also read data.json
+import json
+
+with open("data.json") as f:
+    data = json.load(f)
+print(data)

--- a/gui/src/app/Scripting/Analysis/useAnalysisState.ts
+++ b/gui/src/app/Scripting/Analysis/useAnalysisState.ts
@@ -1,3 +1,4 @@
+import { FileNames } from "@SpCore/FileMapping";
 import {
   InterpreterStatus,
   isInterpreterBusy,
@@ -44,6 +45,16 @@ const useAnalysisState = (latestRun: StanRun) => {
 
   const isDataDefined = useMemo(() => spData !== undefined, [spData]);
 
+  const files = useMemo(() => {
+    if (latestRun.data === undefined) {
+      return undefined;
+    } else {
+      return {
+        [FileNames.DATAFILE]: latestRun.data,
+      };
+    }
+  }, [latestRun.data]);
+
   useEffect(() => {
     if (!isDataDefined) {
       setRunnable(false);
@@ -65,6 +76,7 @@ const useAnalysisState = (latestRun: StanRun) => {
     onStatus: setStatus,
     runnable,
     notRunnableReason,
+    files,
   };
 };
 

--- a/gui/src/app/Scripting/DataGeneration/DataPyWindow.tsx
+++ b/gui/src/app/Scripting/DataGeneration/DataPyWindow.tsx
@@ -39,15 +39,14 @@ const DataPyWindow: FunctionComponent<Props> = () => {
   const handleRun = useCallback(
     (code: string) => {
       clearOutputDivs(consoleRef);
-      run(
+      run({
         code,
-        {},
-        {
+        spRunSettings: {
           loadsDraws: false,
           showsPlots: false,
           producesData: true,
         },
-      );
+      });
     },
     [consoleRef, run],
   );

--- a/gui/src/app/Scripting/pyodide/pyodideWorkerTypes.ts
+++ b/gui/src/app/Scripting/pyodide/pyodideWorkerTypes.ts
@@ -15,6 +15,7 @@ export type MessageToPyodideWorker = {
   code: string;
   spData: Record<string, any> | undefined;
   spRunSettings: PyodideRunSettings;
+  files: Record<string, string> | undefined;
 };
 
 export const isMessageToPyodideWorker = (

--- a/gui/src/app/Scripting/pyodide/usePyodideWorker.ts
+++ b/gui/src/app/Scripting/pyodide/usePyodideWorker.ts
@@ -18,6 +18,13 @@ type PyodideWorkerCallbacks = {
   onImage?: (image: string) => void;
 };
 
+type RunPyProps = {
+  code: string;
+  spData?: Record<string, any>;
+  spRunSettings: PyodideRunSettings;
+  files?: Record<string, string>;
+};
+
 class PyodideWorkerInterface {
   #worker: Worker | undefined;
 
@@ -71,16 +78,13 @@ class PyodideWorkerInterface {
     return { worker, cleanup };
   }
 
-  run(
-    code: string,
-    spData: Record<string, any> | undefined,
-    spRunSettings: PyodideRunSettings,
-  ) {
+  run({ code, spData, spRunSettings, files }: RunPyProps) {
     const msg: MessageToPyodideWorker = {
       type: "run",
       code,
       spData,
       spRunSettings,
+      files,
     };
     if (this.#worker) {
       this.#worker.postMessage(msg);
@@ -114,13 +118,9 @@ const usePyodideWorker = (callbacks: {
   }, [callbacks]);
 
   const run = useCallback(
-    (
-      code: string,
-      spData: Record<string, any> | undefined,
-      spRunSettings: PyodideRunSettings,
-    ) => {
+    (p: RunPyProps) => {
       if (worker) {
-        worker.run(code, spData, spRunSettings);
+        worker.run(p);
       } else {
         throw new Error("pyodide worker is not defined");
       }

--- a/gui/src/app/StanSampler/StanSampler.ts
+++ b/gui/src/app/StanSampler/StanSampler.ts
@@ -100,7 +100,7 @@ class StanSampler {
     };
     if (!this.#stanWorker) throw new Error("model worker is undefined");
 
-    this.update({ type: "startSampling", samplingOpts });
+    this.update({ type: "startSampling", samplingOpts, data });
 
     this.#samplingStartTimeSec = Date.now() / 1000;
     this.postMessage({ purpose: Requests.Sample, sampleConfig });

--- a/gui/src/app/StanSampler/useStanSampler.ts
+++ b/gui/src/app/StanSampler/useStanSampler.ts
@@ -11,6 +11,7 @@ export type StanRun = {
   errorMessage: string;
   progress?: Progress;
   samplingOpts?: SamplingOpts;
+  data?: string;
   draws?: number[][];
   paramNames?: string[];
   computeTimeSec?: number;
@@ -35,6 +36,7 @@ export type StanRunAction =
   | {
       type: "startSampling";
       samplingOpts: SamplingOpts;
+      data: string;
     }
   | {
       type: "samplerReturn";
@@ -65,6 +67,7 @@ export const StanRunReducer = (
         status: "sampling",
         errorMessage: "",
         samplingOpts: action.samplingOpts,
+        data: action.data,
       };
     case "samplerReturn":
       return {


### PR DESCRIPTION
Closes #238.

- Adds data to the `latestRun` object
- Adds a `files` argument to the pyodide and webr mechanisms to allow us to populate arbitrary files

This sets the SIR analysis.R example go from 
```R
# posterior predictive check using the pred_cases generated quantity

install.packages(c("outbreaks", "bayesplot"))
library(outbreaks)
library(posterior)
library(ggplot2)

# same as data generation
cases <- influenza_england_1978_school$in_bed
n_days <- length(cases)
ts <- 1:n_days

# Extract posterior predictive checks
pred_cases <- as.matrix(as_draws_df(as_draws_rvars(draws)$pred_cases))[, -(15:17)]

bayesplot::ppc_ribbon(y = cases, yrep = pred_cases,
                      x = ts, y_draw = "point") +
  theme_bw() +
  ylab("cases") + xlab("days")
```

to 

```R
# posterior predictive check using the pred_cases generated quantity

install.packages("bayesplot")
library(outbreaks)
library(posterior)
library(ggplot2)

# load from data
d <- jsonlite::read_json('./data.json')
cases <- unlist(d$cases)
n_days <- d$n_days
ts <- unlist(d$ts)

# Extract posterior predictive checks
pred_cases <- as.matrix(as_draws_df(as_draws_rvars(draws)$pred_cases))[, -(15:17)]

bayesplot::ppc_ribbon(y = cases, yrep = pred_cases,
                      x = ts, y_draw = "point") +
  theme_bw() +
  ylab("cases") + xlab("days")
```

This will be even nicer if the data has some randomization to it, in which case re-running the same code in analysis would not recover the same data, but this would allow it to