### PR TITLE
Ignore commitFile if contents are identical

### DIFF
--- a/gui/src/app/Project/ProjectReducer.ts
+++ b/gui/src/app/Project/ProjectReducer.ts
@@ -70,6 +70,9 @@ const ProjectReducer = (s: ProjectDataModel, a: ProjectReducerAction) => {
       return { ...s, ephemera: newEphemera };
     }
     case "commitFile": {
+      if (s[a.filename] === s.ephemera[a.filename]) {
+        return s;
+      }
       const newState = { ...s };
       const newDataSource = confirmDataSourceForCommit(
         s.meta.dataSource,

--- a/gui/test/app/Project/ProjectReducer.test.ts
+++ b/gui/test/app/Project/ProjectReducer.test.ts
@@ -133,6 +133,12 @@ describe("Project reducer", () => {
       ephemera: { ...ephemeralFiles },
       meta: { dataSource: DataSource.GENERATED_BY_PYTHON },
     } as any as ProjectDataModel;
+
+    const editAction: ProjectReducerAction = {
+      type: "editFile",
+      content: "new content",
+      filename: ProjectKnownFiles.DATAFILE,
+    };
     const commitAction: ProjectReducerAction = {
       type: "commitFile",
       filename: ProjectKnownFiles.DATAFILE,
@@ -181,9 +187,34 @@ describe("Project reducer", () => {
           ...initialState,
           meta: { dataSource: p.source },
         } as any as ProjectDataModel;
+        const edit = { ...editAction, filename: p.file };
+        const edited = ProjectReducer(initial, edit);
+        const commit = { ...commitAction, filename: p.file };
+        const result = ProjectReducer(edited, commit);
+        expect(result.meta.dataSource).toEqual(p.newSource);
+      });
+    });
+
+    test("Commiting identical data generation script does not change status", () => {
+      const pairs = [
+        {
+          source: DataSource.GENERATED_BY_PYTHON,
+          file: ProjectKnownFiles.DATAPYFILE,
+        },
+        {
+          source: DataSource.GENERATED_BY_R,
+          file: ProjectKnownFiles.DATARFILE,
+        },
+      ];
+      pairs.forEach((p) => {
+        const initial = {
+          ...initialState,
+          meta: { dataSource: p.source },
+        } as any as ProjectDataModel;
+
         const commit = { ...commitAction, filename: p.file };
         const result = ProjectReducer(initial, commit);
-        expect(result.meta.dataSource).toEqual(p.newSource);
+        expect(result.meta.dataSource).toEqual(p.source);
       });
     });
     test("Saving data generation script does not change status for data.json it didn't generate", () => {


### PR DESCRIPTION
#236 had a small oddity, which is if you pressed `Ctrl+S` in an unmodified data.R/py window, it would label the data as 'stale' even though it was not. This avoids the issue by ignoring entirely no-op commits