### PR TITLE
Don't cache data contents in script state

### DIFF
--- a/gui/src/app/Scripting/DataGeneration/useDataGenState.ts
+++ b/gui/src/app/Scripting/DataGeneration/useDataGenState.ts
@@ -10,37 +10,24 @@ const useDataGenState = (source: "python" | "r") => {
   const [status, setStatus] = useState<InterpreterStatus>("idle");
   const consoleRef = useRef<HTMLDivElement>(null);
 
-  const { data, update } = useContext(ProjectContext);
+  const { update } = useContext(ProjectContext);
 
-  // we don't want the callback to force itself to re-render when data is set
-  const lastData = useRef(data.dataFileContent);
   const onData = useCallback(
     (newData: unknown) => {
-      const dataJson = JSON.stringify(newData, null, 2);
-
-      if (dataJson !== lastData.current) {
-        lastData.current = dataJson;
-        update({
-          type: "generateData",
-          content: dataJson,
-          dataSource:
-            source === "python"
-              ? DataSource.GENERATED_BY_PYTHON
-              : DataSource.GENERATED_BY_R,
-        });
-        // Use "stan-playground" prefix to distinguish from console output of the running code
-        writeConsoleOutToDiv(
-          consoleRef,
-          "[stan-playground] Data updated",
-          "stdout",
-        );
-      } else {
-        writeConsoleOutToDiv(
-          consoleRef,
-          "[stan-playground] Data unchanged",
-          "stdout",
-        );
-      }
+      update({
+        type: "generateData",
+        content: JSON.stringify(newData, null, 2),
+        dataSource:
+          source === "python"
+            ? DataSource.GENERATED_BY_PYTHON
+            : DataSource.GENERATED_BY_R,
+      });
+      // Use "stan-playground" prefix to distinguish from console output of the running code
+      writeConsoleOutToDiv(
+        consoleRef,
+        "[stan-playground] Data updated",
+        "stdout",
+      );
     },
     [update, consoleRef],
   );


### PR DESCRIPTION
In 8de418f617e51ddd6df01aadf24fc49c26731848, I made it so the data.py/R scripts wouldn't update the text if the data they just generated was exactly the same. This was a nice-enough quality of life feature, but it caused a lot of unnecessary re-renders, which I "fixed" in 805ca1b67dbb4d88c2e34013ea8ee4b5b648b379.

However, this has several other bugs if the output of your script is deterministic. The easiest to see is:
1. Run a deterministic data.R
2. Edit data.json, save
3. Re-run data.R, observe that it claims the data is unchanged. 

I considered several refactors to save this feature, but all seemed too complicated to justify their use, so I'm proposing we just ditch it and always update the data after a successful script run. 