### PR TITLE
Allow newer arviz in pyodide

### DIFF
--- a/gui/src/app/Scripting/pyodide/pyodideWorker.ts
+++ b/gui/src/app/Scripting/pyodide/pyodideWorker.ts
@@ -105,7 +105,7 @@ const run = async (
         packageFutures.push(pyodide.loadPackage("matplotlib"));
 
         if (script.includes("arviz")) {
-          packageFutures.push(micropip.install("arviz<0.18"));
+          packageFutures.push(micropip.install("arviz"));
         }
       }
       packageFutures.push(micropip.install("stanio"));


### PR DESCRIPTION
We were installing `arviz<0.18`, because that version added a dependency on `dm-tree`, which wasn't WASM compatible. The latest arviz (`0.20`) has made that dependency optional, so the pinning is no longer necessary 