### PR TITLE
Normalize newlines before passing to scripts

### DIFF
--- a/gui/src/app/Scripting/ScriptEditor.tsx
+++ b/gui/src/app/Scripting/ScriptEditor.tsx
@@ -5,6 +5,7 @@ import { ColorOptions, ToolbarItem } from "@SpComponents/ToolBar";
 import { FileNames } from "@SpCore/FileMapping";
 import { ProjectContext } from "@SpCore/ProjectContextProvider";
 import { ProjectKnownFiles } from "@SpCore/ProjectDataModel";
+import { normalizeLineEndings } from "@SpUtil/normalizeLineEndings";
 import {
   FunctionComponent,
   RefObject,
@@ -67,7 +68,7 @@ const ScriptEditor: FunctionComponent<ScriptEditorProps> = ({
   }, [dataKey, update]);
 
   const runCode = useCallback(() => {
-    onRun(content);
+    onRun(normalizeLineEndings(content));
   }, [content, onRun]);
 
   const unsavedChanges = useMemo(() => {

--- a/gui/src/app/util/normalizeLineEndings.ts
+++ b/gui/src/app/util/normalizeLineEndings.ts
@@ -1,0 +1,3 @@
+export const normalizeLineEndings = (str: string) => {
+  return str.replace(/\r\n/g, "\n");
+};

--- a/gui/test/app/util/normalizeLineEndings.test.ts
+++ b/gui/test/app/util/normalizeLineEndings.test.ts
@@ -1,0 +1,15 @@
+import { normalizeLineEndings } from "@SpUtil/normalizeLineEndings";
+import { describe, expect, test } from "vitest";
+
+describe("normalizeLineEndings", () => {
+  test("should replace all CRLF with LF", () => {
+    const actual = normalizeLineEndings("foo\r\nbar\r\nbaz\r\n");
+    expect(actual).toBe("foo\nbar\nbaz\n");
+  });
+
+  test("leaves LF alone", () => {
+    const before = "foo\nbar\nbaz\n";
+    const actual = normalizeLineEndings(before);
+    expect(actual).toBe(before);
+  });
+});


### PR DESCRIPTION
Reported here: https://discourse.mc-stan.org/t/stan-playground-issues-with-pasting-scripts/37498

WebR complains about invalid tokens if given windows CRLF line endings. The easiest way to test this on non-windows is save a file in your editor using these endings, and then use the load project window to upload it (copy-pasting seems to remove them, on my Ubuntu machine at least)

I looked through the Monaco docs to see if there was a way we could ask it to do this normalization for us, but it seems there isn't, so I just put it right before we actually shell out to webr or pyodide (pyodide doesn't seem to mind either way)