### PR TITLE
Use Split component to allow sampler output view to take up more vertical space

### DIFF
--- a/gui/src/app/pages/HomePage/SamplingWindow/SamplingWindow.tsx
+++ b/gui/src/app/pages/HomePage/SamplingWindow/SamplingWindow.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent, useCallback, useContext } from "react";
 
+import { Split } from "@geoffcox/react-splitter";
 import Box from "@mui/material/Box";
-import Divider from "@mui/material/Divider";
 import Grid from "@mui/material/Grid";
 import { CompileContext } from "@SpCompilation/CompileContext";
 import RunPanel from "@SpComponents/RunPanel";
@@ -36,7 +36,7 @@ const SamplingWindow: FunctionComponent<SamplingWindowProps> = () => {
   const { sampler, latestRun } = useStanSampler(compiledMainJsUrl);
   const isSampling = latestRun.status === "sampling";
   return (
-    <Box height="100%" display="flex" flexDirection="column">
+    <Split horizontal initialPrimarySize="30%" minSecondarySize="10%">
       <Grid container>
         <Grid item xs={12} sm={4}>
           <SamplingOptsPanel
@@ -54,11 +54,12 @@ const SamplingWindow: FunctionComponent<SamplingWindowProps> = () => {
           />
         </Grid>
       </Grid>
-      <Divider />
-      <Box flex="1" overflow="hidden">
-        <SamplingResultsArea latestRun={latestRun} />
+      <Box height="100%" display="flex" flexDirection="column">
+        <Box flex="1" overflow="hidden">
+          <SamplingResultsArea latestRun={latestRun} />
+        </Box>
       </Box>
-    </Box>
+    </Split>
   );
 };
 


### PR DESCRIPTION
The default appearance is very similar to the current site, but you can now utilize basically the entire right panel for analysis if you want to
![image](https://github.com/user-attachments/assets/7f415158-6546-4c77-b659-d259782b6bd4)

Closes #251 