### PR TITLE
Add console text output tab

### DIFF
--- a/gui/src/app/SamplerOutputView/SamplerOutputView.tsx
+++ b/gui/src/app/SamplerOutputView/SamplerOutputView.tsx
@@ -1,4 +1,7 @@
 import { Download } from "@mui/icons-material";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import IconButton from "@mui/material/IconButton";
 import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
 import TableCell from "@mui/material/TableCell";
@@ -7,8 +10,6 @@ import {
   SuccessBorderedTableRow,
   SuccessColoredTableHead,
 } from "@SpComponents/StyledTables";
-import Button from "@mui/material/Button";
-import { IconButton } from "@mui/material";
 import HistsView from "@SpComponents/HistsView";
 import SummaryView from "@SpComponents/SummaryView";
 import TabWidget from "@SpComponents/TabWidget";
@@ -26,15 +27,17 @@ type SamplerOutputViewProps = {
 const SamplerOutputView: FunctionComponent<SamplerOutputViewProps> = ({
   latestRun,
 }) => {
-  const { draws, paramNames, computeTimeSec, samplingOpts } = latestRun;
+  const { draws, paramNames, computeTimeSec, samplingOpts, consoleText } =
+    latestRun;
 
-  if (!draws || !paramNames || !samplingOpts) return <span />;
+  if (!draws || !paramNames || !samplingOpts || !consoleText) return <span />;
   return (
     <DrawsDisplay
       draws={draws}
       paramNames={paramNames}
       computeTimeSec={computeTimeSec}
       samplingOpts={samplingOpts}
+      consoleText={consoleText}
     />
   );
 };
@@ -44,6 +47,7 @@ type DrawsDisplayProps = {
   paramNames: string[];
   computeTimeSec: number | undefined;
   samplingOpts: SamplingOpts;
+  consoleText: string;
 };
 
 const DrawsDisplay: FunctionComponent<DrawsDisplayProps> = ({
@@ -51,6 +55,7 @@ const DrawsDisplay: FunctionComponent<DrawsDisplayProps> = ({
   paramNames,
   computeTimeSec,
   samplingOpts,
+  consoleText,
 }) => {
   const numChains = samplingOpts.num_chains;
 
@@ -68,7 +73,9 @@ const DrawsDisplay: FunctionComponent<DrawsDisplayProps> = ({
   }, [draws, numChains]);
 
   return (
-    <TabWidget labels={["Summary", "Draws", "Histograms", "Trace plots"]}>
+    <TabWidget
+      labels={["Summary", "Draws", "Histograms", "Trace plots", "Console"]}
+    >
       <SummaryView
         draws={draws}
         paramNames={paramNames}
@@ -92,7 +99,20 @@ const DrawsDisplay: FunctionComponent<DrawsDisplayProps> = ({
         paramNames={paramNames}
         drawChainIds={drawChainIds}
       />
+      <ConsoleOutput text={consoleText} />
     </TabWidget>
+  );
+};
+
+type ConsoleOutputProps = {
+  text: string;
+};
+
+const ConsoleOutput: FunctionComponent<ConsoleOutputProps> = ({ text }) => {
+  return (
+    <Box className="stdout" color="info.dark">
+      <pre>{text}</pre>
+    </Box>
   );
 };
 

--- a/gui/src/app/SamplerOutputView/SamplerOutputView.tsx
+++ b/gui/src/app/SamplerOutputView/SamplerOutputView.tsx
@@ -27,10 +27,10 @@ type SamplerOutputViewProps = {
 const SamplerOutputView: FunctionComponent<SamplerOutputViewProps> = ({
   latestRun,
 }) => {
-  const { draws, paramNames, computeTimeSec, samplingOpts, consoleText } =
-    latestRun;
+  const { samplingOpts, runResult } = latestRun;
+  if (!runResult || !samplingOpts) return <span />;
+  const { draws, paramNames, computeTimeSec, consoleText } = runResult;
 
-  if (!draws || !paramNames || !samplingOpts || !consoleText) return <span />;
   return (
     <DrawsDisplay
       draws={draws}

--- a/gui/src/app/Scripting/Analysis/useAnalysisState.ts
+++ b/gui/src/app/Scripting/Analysis/useAnalysisState.ts
@@ -22,9 +22,10 @@ const useAnalysisState = (latestRun: StanRun) => {
 
   useEffect(() => {
     clearOutputDivs(consoleRef, imagesRef);
-  }, [latestRun.draws]);
+  }, [latestRun.runResult?.draws]);
 
-  const { draws, paramNames, samplingOpts, status: samplerStatus } = latestRun;
+  const { runResult, samplingOpts, status: samplerStatus } = latestRun;
+  const { draws, paramNames } = runResult || {};
   const numChains = samplingOpts?.num_chains;
   const spData = useMemo(() => {
     if (samplerStatus === "completed" && draws && numChains && paramNames) {

--- a/gui/src/app/StanSampler/StanSampler.ts
+++ b/gui/src/app/StanSampler/StanSampler.ts
@@ -78,6 +78,7 @@ class StanSampler {
               draws: e.data.draws,
               paramNames: e.data.paramNames,
               computeTimeSec: Date.now() / 1000 - this.#samplingStartTimeSec,
+              consoleText: e.data.consoleText,
             });
           }
           break;

--- a/gui/src/app/StanSampler/useStanSampler.ts
+++ b/gui/src/app/StanSampler/useStanSampler.ts
@@ -10,12 +10,14 @@ export type StanRun = {
   status: StanSamplerStatus;
   errorMessage: string;
   progress?: Progress;
-  consoleText?: string;
   samplingOpts?: SamplingOpts;
   data?: string;
-  draws?: number[][];
-  paramNames?: string[];
-  computeTimeSec?: number;
+  runResult?: {
+    consoleText: string;
+    draws: number[][];
+    paramNames: string[];
+    computeTimeSec: number;
+  };
 };
 
 const initialStanRun: StanRun = {
@@ -75,10 +77,12 @@ export const StanRunReducer = (
       return {
         ...state,
         status: "completed",
-        draws: action.draws,
-        paramNames: action.paramNames,
-        computeTimeSec: action.computeTimeSec,
-        consoleText: action.consoleText,
+        runResult: {
+          draws: action.draws,
+          paramNames: action.paramNames,
+          computeTimeSec: action.computeTimeSec,
+          consoleText: action.consoleText,
+        },
       };
     default:
       return unreachable(action);

--- a/gui/src/app/StanSampler/useStanSampler.ts
+++ b/gui/src/app/StanSampler/useStanSampler.ts
@@ -10,6 +10,7 @@ export type StanRun = {
   status: StanSamplerStatus;
   errorMessage: string;
   progress?: Progress;
+  consoleText?: string;
   samplingOpts?: SamplingOpts;
   data?: string;
   draws?: number[][];
@@ -43,6 +44,7 @@ export type StanRunAction =
       draws: number[][];
       paramNames: string[];
       computeTimeSec: number;
+      consoleText: string;
     };
 
 export const StanRunReducer = (
@@ -76,6 +78,7 @@ export const StanRunReducer = (
         draws: action.draws,
         paramNames: action.paramNames,
         computeTimeSec: action.computeTimeSec,
+        consoleText: action.consoleText,
       };
     default:
       return unreachable(action);

--- a/gui/test/app/StanSampler/useStanSampler.test.ts
+++ b/gui/test/app/StanSampler/useStanSampler.test.ts
@@ -131,7 +131,9 @@ describe("useStanSampler", () => {
 
       await waitFor(() => {
         expect(result.current.latestRun.status).toBe("completed");
-        expect(result.current.latestRun.paramNames).toEqual(mockedParamNames);
+        expect(result.current.latestRun.runResult?.paramNames).toEqual(
+          mockedParamNames,
+        );
       });
       expect(mockedStderr).not.toHaveBeenCalled();
     });
@@ -178,7 +180,9 @@ describe("useStanSampler", () => {
 
       await waitFor(() => {
         expect(result.current.latestRun.status).toBe("completed");
-        expect(result.current.latestRun.paramNames).toEqual(mockedParamNames);
+        expect(result.current.latestRun.runResult?.paramNames).toEqual(
+          mockedParamNames,
+        );
       });
 
       expect(mockedStderr).not.toHaveBeenCalled();
@@ -206,17 +210,21 @@ describe("useStanSampler", () => {
   describe("outputs", () => {
     test("undefined sampler returns undefined", () => {
       const { result } = renderHook(() => useStanSampler(undefined));
-      expect(result.current.latestRun.draws).toBeUndefined();
-      expect(result.current.latestRun.paramNames).toBeUndefined();
-      expect(result.current.latestRun.computeTimeSec).toBeUndefined();
+      expect(result.current.latestRun.runResult?.draws).toBeUndefined();
+      expect(result.current.latestRun.runResult?.paramNames).toBeUndefined();
+      expect(
+        result.current.latestRun.runResult?.computeTimeSec,
+      ).toBeUndefined();
     });
 
     test("sampling changes output", async () => {
       const { result } = await loadedSampler();
 
-      expect(result.current.latestRun.draws).toBeUndefined();
-      expect(result.current.latestRun.paramNames).toBeUndefined();
-      expect(result.current.latestRun.computeTimeSec).toBeUndefined();
+      expect(result.current.latestRun.runResult?.draws).toBeUndefined();
+      expect(result.current.latestRun.runResult?.paramNames).toBeUndefined();
+      expect(
+        result.current.latestRun.runResult?.computeTimeSec,
+      ).toBeUndefined();
       expect(result.current.latestRun.samplingOpts).toBeUndefined();
 
       const testingSamplingOpts = {
@@ -229,10 +237,15 @@ describe("useStanSampler", () => {
       });
 
       await waitFor(() => {
-        expect(result.current.latestRun.draws).toEqual(mockedDraws);
-        expect(result.current.latestRun.paramNames).toEqual(mockedParamNames);
         expect(result.current.latestRun.samplingOpts).toBe(testingSamplingOpts);
-        expect(result.current.latestRun.computeTimeSec).toBeDefined();
+        expect(result.current.latestRun.runResult).toBeDefined();
+        expect(result.current.latestRun.runResult?.draws).toEqual(mockedDraws);
+        expect(result.current.latestRun.runResult?.paramNames).toEqual(
+          mockedParamNames,
+        );
+        expect(
+          result.current.latestRun.runResult?.computeTimeSec,
+        ).toBeDefined();
       });
 
       expect(result.current.latestRun.status).toBe("completed");


### PR DESCRIPTION
Closes #260 

I ended up _not_ doing something live because this would dramatically slow down the sampling if a print statement was present in the model block. Now it only _slightly_ slows it down, at the cost of not being live. If a user really wants to monitor the output live, they still can use the developer console.

![image](https://github.com/user-attachments/assets/ab43abfc-9c36-4164-8996-b6dc7fdb2320)
