### PR TITLE
Improve LazyPlotlyPlot lagging on resize

### DIFF
--- a/gui/src/app/components/LazyPlotlyPlot.tsx
+++ b/gui/src/app/components/LazyPlotlyPlot.tsx
@@ -1,9 +1,9 @@
 import CircularProgress from "@mui/material/CircularProgress";
-import React, { FunctionComponent, Suspense } from "react";
+import React, { FunctionComponent, Suspense, useMemo } from "react";
+import useMeasure from "react-use-measure";
 
 import type { PlotParams } from "react-plotly.js";
 import createPlotlyComponent from "react-plotly.js/factory";
-import useMeasure from "react-use-measure";
 const Plot = React.lazy(async () => {
   const plotly = await import("plotly.js-cartesian-dist");
   return { default: createPlotlyComponent(plotly) };
@@ -11,26 +11,29 @@ const Plot = React.lazy(async () => {
 
 const LazyPlotlyPlot: FunctionComponent<PlotParams> = ({ data, layout }) => {
   // plotly has a reactive setting, but it is buggy
-  const [ref, { width }] = useMeasure();
+  const [ref, { width }] = useMeasure({ debounce: 100 });
 
-  const layoutWithWidth = {
-    ...layout,
-    width: width,
-  };
+  const layoutWithWidth = useMemo(
+    () => ({
+      ...layout,
+      width: width,
+    }),
+    [layout, width],
+  );
 
   return (
-    <div ref={ref}>
-      <Suspense
-        fallback={
-          <>
-            <CircularProgress />
-            <p>Loading Plotly.js</p>
-          </>
-        }
-      >
+    <Suspense
+      fallback={
+        <div className="PlotLoader">
+          <CircularProgress color="info" />
+          <p className="details">Loading Plotly.js</p>
+        </div>
+      }
+    >
+      <div ref={ref}>
         <Plot data={data} layout={layoutWithWidth} />
-      </Suspense>
-    </div>
+      </div>
+    </Suspense>
   );
 };
 

--- a/gui/src/localStyles.css
+++ b/gui/src/localStyles.css
@@ -188,6 +188,12 @@ span.EditorTitle {
   height: 4px;
 }
 
+.PlotLoader {
+  padding: 10px;
+  display: grid;
+  place-items: center;
+}
+
 /* Sampling Opts ------ */
 .SamplingOptsWrapper {
   padding: 10px;


### PR DESCRIPTION
This uses the `debounce` option to `useMeasure` to make it so the plots don't get re-drawn quite so often when resizing the output view. The UI lags significantly less now when the "histograms" output is active and the slider is dragged to widen that side of the screen.

I also tweaked the visuals of the fallback, since I spent some time staring at them during testing