### PR TITLE
Tweak backend settings for better binary sizes

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -22,6 +22,7 @@ RUN mkdir oneTBB/build && cd oneTBB/build && \
     emcmake cmake .. \
     -DCMAKE_CXX_COMPILER=em++ \
     -DCMAKE_C_COMPILER=emcc \
+    -DCMAKE_BUILD_TYPE=MinSizeRel \
     -DTBB_STRICT=OFF \
     -DCMAKE_CXX_FLAGS="-fwasm-exceptions -Wno-unused-command-line-argument" \
     -DTBB_DISABLE_HWLOC_AUTOMATIC_SEARCH=ON \
@@ -40,7 +41,7 @@ RUN pip install uvicorn
 # Clone the TinyStan repository and checkout a specific commit
 RUN git clone https://github.com/WardBrian/tinystan.git && \
     cd tinystan && \
-    git checkout "28e4156837260d8e752dfc50c00fbe2409236c11" && \
+    git checkout "17f6cf732a0d9adfc5211fef4474905c92e219a9" && \
     git submodule update --init --recursive
 
 # Copy the local configuration file for TinyStan

--- a/backend/local.mk
+++ b/backend/local.mk
@@ -9,11 +9,13 @@ TBB_LIB=/app/oneTBB/install/lib/
 LDFLAGS_TBB ?= -Wl,-L,"$(TBB_LIB)"
 LDLIBS_TBB ?= -ltbb
 
+TINYSTAN_SERIAL=true
+
 # could also uses -fexceptions which is more compatible, but slower
 CXXFLAGS+=-fwasm-exceptions
 
 LDFLAGS+=-sMODULARIZE -sEXPORT_NAME=createModule -sEXPORT_ES6 -sENVIRONMENT=web -sINCOMING_MODULE_JS_API=print,printErr
 LDFLAGS+=-sEXIT_RUNTIME=1 -sALLOW_MEMORY_GROWTH=1
 # Functions we want. Can add more, with a prepended _, from tinystan.h
-EXPORTS=_malloc,_free,_tinystan_api_version,_tinystan_create_model,_tinystan_destroy_error,_tinystan_destroy_model,_tinystan_get_error_message,_tinystan_get_error_type,_tinystan_model_num_free_params,_tinystan_model_param_names,_tinystan_sample,_tinystan_pathfinder,_tinystan_separator_char,_tinystan_stan_version
+EXPORTS=_malloc,_free,_tinystan_api_version,_tinystan_create_model,_tinystan_destroy_error,_tinystan_destroy_model,_tinystan_get_error_message,_tinystan_get_error_type,_tinystan_model_num_free_params,_tinystan_model_param_names,_tinystan_sample,_tinystan_separator_char,_tinystan_stan_version
 LDFLAGS+=-sEXPORTED_FUNCTIONS=$(EXPORTS) -sEXPORTED_RUNTIME_METHODS=stringToUTF8,getValue,UTF8ToString,lengthBytesUTF8


### PR DESCRIPTION
Saves about 300kb per model (now only about ~1mb in size total). No impact on runtimes (passing -Os saved an extra ~100kb, but would cost ~5% in runtime, so I didn't).

I think this may also slightly improve compile times