### PR TITLE
Add a salt to the model output hash

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -52,8 +52,13 @@ RUN cd tinystan && \
     emmake make test_models/bernoulli/bernoulli.js -j$(nproc) && \
     emstrip test_models/bernoulli/bernoulli.wasm
 
-COPY stan-wasm-server /stan-wasm-server
-WORKDIR /stan-wasm-server
+COPY stan-wasm-server /app/stan-wasm-server
+
+# compute a hash of our app to make the model cache use unique URLS
+# (to avoid browsers caching across different versions)
+RUN find /app/ -type f -print0 | sort -z | xargs -0 sha1sum | sha1sum | cut -d' ' -f1 | tee /app/stan-wasm-server/hash-salt.txt
+
+WORKDIR /app/stan-wasm-server
 
 ENV SWS_PASSCODE=1234
 ENV SWS_LOG_LEVEL=debug


### PR DESCRIPTION
@jsoules brought up an issue I had also seen in #274, which I think is caused by the changes #257 made which, among other things, mean the URL for a given model was stable across backend updates/restarts. 

I think this is actually a bad thing, since it can mean a compilation result is served from the user's local cache rather than the server. Even if this isn't the source of the weird loading behavior we've both seen, it certain would cause issues if we needed to change something about the returned model's API that needed a simultaneous backend and frontend update.

This PR does the simplest fix I could think of, which is the docker build now computes a hash of all of the application files, and this hash is used to salt the model output folder generation. This means in a given build, all the workers will still compute the same hashes, but changing any file in our code or in the tinystan or tbb dependencies will lead to new URLs for the same models. 