### PR TITLE
Remove Ctrl+C for cancellation due to it shadowing Copy

### DIFF
--- a/gui/src/app/components/FileEditor/ScriptEditor.tsx
+++ b/gui/src/app/components/FileEditor/ScriptEditor.tsx
@@ -95,19 +95,8 @@ const ScriptEditor: FunctionComponent<ScriptEditorProps> = ({
         },
       },
     ];
-    if (onCancel) {
-      // Ctrl-C to cancel
-      actions.push({
-        id: "cancel-script",
-        label: "Cancel Script",
-        keybindings: [
-          monacoInstance.KeyMod.CtrlCmd | monacoInstance.KeyCode.KeyC,
-        ],
-        run: onCancel,
-      });
-    }
     return actions;
-  }, [monacoInstance, onCancel, runCode, runnable, unsavedChanges]);
+  }, [monacoInstance, runCode, runnable, unsavedChanges]);
 
   const toolbarItems: ToolbarItem[] = useMemo(() => {
     return makeToolbar({


### PR DESCRIPTION
In retrospect I should have noticed this...

If users are clamoring for easier cancellation we can always add it back under a different keybind (`Ctrl+Shift+C`?)