### PR TITLE
More user-friendly variable names on output views

### DIFF
--- a/gui/src/app/areas/ControlArea/SamplingArea/ResultsArea/SamplerOutputArea/HistogramsPanel.tsx
+++ b/gui/src/app/areas/ControlArea/SamplingArea/ResultsArea/SamplerOutputArea/HistogramsPanel.tsx
@@ -2,6 +2,7 @@ import Button from "@mui/material/Button";
 import ResponsiveGrid from "@SpComponents/ResponsiveGrid";
 import Histogram from "./Histogram";
 import { FunctionComponent, useMemo, useState } from "react";
+import prettifyStanParamName from "@SpUtil/prettifyStanParamName";
 
 type HistogramsProps = {
   draws: number[][];
@@ -15,23 +16,36 @@ const HistogramsPanel: FunctionComponent<HistogramsProps> = ({
 }) => {
   const paramNamesResorted = useMemo(() => {
     // put the names that don't end with __ first
-    const names = paramNames.filter((name) => !name.endsWith("__"));
-    const namesWithSuffix = paramNames.filter((name) => name.endsWith("__"));
+    const names: [string, number][] = [];
+    const namesWithSuffix: [string, number][] = [];
+
+    for (const [index, name] of paramNames
+      .map(prettifyStanParamName)
+      .entries()) {
+      if (name.endsWith("__")) {
+        namesWithSuffix.push([name, index]);
+      } else {
+        names.push([name, index]);
+      }
+    }
     return [...names, ...namesWithSuffix];
   }, [paramNames]);
+
   const [abbreviatedToNumPlots, setAbbreviatedToNumPlots] =
     useState<number>(30);
   return (
     <>
       <ResponsiveGrid>
-        {paramNamesResorted.slice(0, abbreviatedToNumPlots).map((paramName) => (
-          <Histogram
-            key={paramName}
-            histData={draws[paramNames.indexOf(paramName)]}
-            title={paramName}
-            variableName={paramName}
-          />
-        ))}
+        {paramNamesResorted
+          .slice(0, abbreviatedToNumPlots)
+          .map(([paramName, index]) => (
+            <Histogram
+              key={paramName}
+              histData={draws[index]}
+              title={paramName}
+              variableName={paramName}
+            />
+          ))}
       </ResponsiveGrid>
       {abbreviatedToNumPlots < paramNamesResorted.length && (
         <div className="PlotAbbreviationToggle">

--- a/gui/src/app/areas/ControlArea/SamplingArea/ResultsArea/SamplerOutputArea/SummaryPanel.tsx
+++ b/gui/src/app/areas/ControlArea/SamplingArea/ResultsArea/SamplerOutputArea/SummaryPanel.tsx
@@ -7,6 +7,7 @@ import {
   AlternatingTableRow,
   SecondaryColoredTableHead,
 } from "@SpComponents/StyledTables";
+import prettifyStanParamName from "@SpUtil/prettifyStanParamName";
 import {
   effective_sample_size,
   split_potential_scale_reduction,
@@ -88,8 +89,8 @@ const SummaryPanel: FunctionComponent<SummaryProps> = ({
 }) => {
   const rows = useMemo(() => {
     const rows: TableRow[] = [];
-    for (const pname of paramNames) {
-      const pDraws = draws[paramNames.indexOf(pname)];
+    for (const [index, pname] of paramNames.entries()) {
+      const pDraws = draws[index];
       const pDrawsSorted = [...pDraws].sort((a, b) => a - b);
       const ess = computeEss(pDraws, drawChainIds);
       const rhat = computeRhat(pDraws, drawChainIds);
@@ -118,7 +119,7 @@ const SummaryPanel: FunctionComponent<SummaryProps> = ({
         }
       });
       rows.push({
-        key: pname,
+        key: prettifyStanParamName(pname),
         values,
       });
     }

--- a/gui/src/app/areas/ControlArea/SamplingArea/ResultsArea/SamplerOutputArea/TracePlotsPanel.tsx
+++ b/gui/src/app/areas/ControlArea/SamplingArea/ResultsArea/SamplerOutputArea/TracePlotsPanel.tsx
@@ -2,6 +2,7 @@ import type { FunctionComponent } from "react";
 
 import Collapsable from "@SpComponents/Collapsable";
 import TracePlot from "./TracePlot";
+import prettifyStanParamName from "@SpUtil/prettifyStanParamName";
 
 type TracePlotsProps = {
   draws: number[][];
@@ -16,7 +17,7 @@ const TracePlotsPanel: FunctionComponent<TracePlotsProps> = ({
 }) => {
   return (
     <>
-      {paramNames.map((paramName, i) => (
+      {paramNames.map(prettifyStanParamName).map((paramName, i) => (
         <Collapsable name={paramName} key={paramName}>
           <TracePlot
             key={paramName}

--- a/gui/src/app/util/prettifyStanParamName.ts
+++ b/gui/src/app/util/prettifyStanParamName.ts
@@ -1,0 +1,31 @@
+// The parameter names as-output is not super user-friendly,
+// so this converts it to the syntax you'd use to access in Stan
+const prettifyStanParamName = (stanParamName: string): string => {
+  if (!stanParamName.includes(":") && !stanParamName.includes(".")) {
+    return stanParamName;
+  }
+  // : means a tuple piece, . means a rectangular container index
+  const parts = stanParamName.split(":").map((part) => {
+    if (!part.includes(".")) {
+      return part;
+    }
+
+    const pos = part.indexOf(".");
+    if (pos <= 0) {
+      return part;
+    }
+    // within any given tuple chunk, replace the first . with an opening
+    // bracket, the rest with commas
+    return (
+      part.substring(0, pos) +
+      "[" +
+      part.substring(pos + 1).replace(/\./g, ",") +
+      "]"
+    );
+  });
+
+  // tuple indexing in the Stan language uses .
+  return parts.join(".");
+};
+
+export default prettifyStanParamName;

--- a/gui/test/app/util/prettifyStanParamName.test.ts
+++ b/gui/test/app/util/prettifyStanParamName.test.ts
@@ -1,0 +1,35 @@
+import prettifyStanParamName from "@SpUtil/prettifyStanParamName";
+import { describe, expect, test } from "vitest";
+
+describe("normalizeLineEndings", () => {
+  test("Basic name is untouched", () => {
+    const before = "alpha";
+    const actual = prettifyStanParamName(before);
+    expect(actual).toBe(before);
+  });
+
+  test("Basic indexing gets rewritten", () => {
+    const actual = prettifyStanParamName("theta.7");
+    expect(actual).toStrictEqual("theta[7]");
+  });
+
+  test("Tuple access gets rewritten", () => {
+    const actual = prettifyStanParamName("foo:1");
+    expect(actual).toStrictEqual("foo.1");
+  });
+
+  test("Multidimensional indexing gets combined", () => {
+    const actual = prettifyStanParamName("bar.3.2.4");
+    expect(actual).toStrictEqual("bar[3,2,4]");
+  });
+
+  test("Nested tuples get rewritten", () => {
+    const actual = prettifyStanParamName("flub:3:2:4");
+    expect(actual).toStrictEqual("flub.3.2.4");
+  });
+
+  test("Combinations of tuples and indexing are handled", () => {
+    const actual = prettifyStanParamName("psi:1.2.3:2.4");
+    expect(actual).toStrictEqual("psi.1[2,3].2[4]");
+  });
+});


### PR DESCRIPTION
The parameter names directly out of Stan are formatted such that they can be a CSV header row, which means they avoid using `,`s. This means they don't always look like the most 'natural' representation to the user.

This performs the [canonical transformation](https://github.com/stan-dev/stan/blob/d4c6ae376bba1b754b7e7cdbe9269dce93958065/src/stan/io/stan_csv_reader.hpp#L16) for these names such that they look more like they would if the user was trying to access that element in Stan itself.

For example, `pred_cases.2`, the second element of the `pred_cases` array in the disease transmission example, will be shown as `pred_cases[2]` on the plots and summary table. Note that the draws table still uses the CSV-safe name, since we allow downloading it as one.