### PR TITLE
Uniformly sort diagnostics to the end of draws output

### DIFF
--- a/gui/src/app/areas/ControlArea/SamplingArea/ResultsArea/SamplerOutputArea.tsx
+++ b/gui/src/app/areas/ControlArea/SamplingArea/ResultsArea/SamplerOutputArea.tsx
@@ -28,15 +28,29 @@ const SamplerOutputArea: FunctionComponent<{ latestRun: StanRun }> = ({
   const variables = useMemo(() => {
     const numChains = sampleConfig.num_chains;
 
-    return paramNames.map((name, index) => ({
-      name: prettifyStanParamName(name),
-      // split the draws into separate chains
-      draws: [...new Array(numChains)].map((_, chain) => {
-        return draws[index].filter(
-          (_, i) => Math.floor((i / draws[0].length) * numChains) === chain,
-        );
-      }),
-    }));
+    const vars: StanDraw[] = [];
+    const varsWithSuffix: StanDraw[] = [];
+
+    for (const [index, name] of paramNames.entries()) {
+      const v = {
+        name: prettifyStanParamName(name),
+        // split the draws into separate chains
+        draws: [...new Array(numChains)].map((_, chain) => {
+          return draws[index].filter(
+            (_, i) => Math.floor((i / draws[0].length) * numChains) === chain,
+          );
+        }),
+      };
+
+      if (v.name.endsWith("__")) {
+        varsWithSuffix.push(v);
+      } else {
+        vars.push(v);
+      }
+    }
+
+    // put the names that don't end with __ first
+    return [...vars, ...varsWithSuffix];
   }, [draws, paramNames, sampleConfig.num_chains]);
 
   return (

--- a/gui/src/app/areas/ControlArea/SamplingArea/ResultsArea/SamplerOutputArea/HistogramsPanel.tsx
+++ b/gui/src/app/areas/ControlArea/SamplingArea/ResultsArea/SamplerOutputArea/HistogramsPanel.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, useMemo, useState } from "react";
+import { FunctionComponent, useState } from "react";
 
 import Button from "@mui/material/Button";
 
@@ -12,31 +12,16 @@ type HistogramsProps = {
 };
 
 const HistogramsPanel: FunctionComponent<HistogramsProps> = ({ variables }) => {
-  const variablesResorted = useMemo(() => {
-    // put the names that don't end with __ first
-    const vars: StanDraw[] = [];
-    const varsWithSuffix: StanDraw[] = [];
-
-    for (const v of variables) {
-      if (v.name.endsWith("__")) {
-        varsWithSuffix.push(v);
-      } else {
-        vars.push(v);
-      }
-    }
-    return [...vars, ...varsWithSuffix];
-  }, [variables]);
-
   const [abbreviatedToNumPlots, setAbbreviatedToNumPlots] =
     useState<number>(30);
   return (
     <>
       <ResponsiveGrid>
-        {variablesResorted.slice(0, abbreviatedToNumPlots).map((v) => (
+        {variables.slice(0, abbreviatedToNumPlots).map((v) => (
           <Histogram key={v.name} variable={v} />
         ))}
       </ResponsiveGrid>
-      {abbreviatedToNumPlots < variablesResorted.length && (
+      {abbreviatedToNumPlots < variables.length && (
         <div className="PlotAbbreviationToggle">
           <Button
             onClick={() => {


### PR DESCRIPTION
Closes #298. This is the simplest solution, which is just put all the diagnostic parameters at the end of the lists. We already did this for histograms, so just by moving it up a component we get it everywhere we care about. 