### PR TITLE
Removes baseUrl, which is deprecated in new Typescript version.

### DIFF
--- a/gui/tsconfig.json
+++ b/gui/tsconfig.json
@@ -19,14 +19,13 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     /* Imports */
-    "baseUrl": "./src",
     "paths": {
-      "@SpComponents/*": ["app/components/*"],
-      "@SpAreas/*": ["app/areas/*"],
-      "@SpWindows/*": ["app/windows/*"],
-      "@SpCore/*": ["app/core/*"],
-      "@SpUtil/*": ["app/util/*"],
-      "@SpPages/*": ["app/pages/*"]
+      "@SpComponents/*": ["./src/app/components/*"],
+      "@SpAreas/*": ["./src/app/areas/*"],
+      "@SpWindows/*": ["./src/app/windows/*"],
+      "@SpCore/*": ["./src/app/core/*"],
+      "@SpUtil/*": ["./src/app/util/*"],
+      "@SpPages/*": ["./src/app/pages/*"]
     }
   },
   "include": ["src", "test"],


### PR DESCRIPTION
See https://github.com/microsoft/TypeScript/issues/62508 for background.
Using the `baseUrl` key in tsconfig was prompting a deprecation warning. The base directory is no longer required, but if non-`.`, the mitigation is to prepend the full path from tsconfig into the individual paths.

I made this change, removed the key, and recompiled to run locally. Got some hiccups on first load (something to do with reloading due to updated code chunking I think) but everything ran fine on a re-load, and tests all still pass.

This is not an urgent PR, though, just a little future-proofing.