### PR TITLE
Include warnings/errors in Console output tab

### DIFF
--- a/gui/package.json
+++ b/gui/package.json
@@ -39,7 +39,7 @@
     "react-router-dom": "^7.5.3",
     "react-use-measure": "^2.1.1",
     "stanc3": "^2.37.0",
-    "tinystan": "^0.3.1",
+    "tinystan": "^0.3.2",
     "webr": "^0.5.6"
   },
   "devDependencies": {

--- a/gui/src/app/areas/ControlArea/SamplingArea/ResultsArea/SamplerOutputArea.tsx
+++ b/gui/src/app/areas/ControlArea/SamplingArea/ResultsArea/SamplerOutputArea.tsx
@@ -20,7 +20,7 @@ export type StanDraw = {
 const SamplerOutputArea: FunctionComponent<{ latestRun: StanRun }> = ({
   latestRun,
 }) => {
-  const { draws, paramNames, computeTimeSec, consoleText, sampleConfig } =
+  const { draws, paramNames, computeTimeSec, consoleMessages, sampleConfig } =
     latestRun;
 
   // compute a useful re-shaping of the draws which is more convenient for
@@ -73,7 +73,7 @@ const SamplerOutputArea: FunctionComponent<{ latestRun: StanRun }> = ({
       <HistogramsPanel variables={variables} />
       <ScatterPlotsPanel variables={variables} />
       <TracePlotsPanel variables={variables} />
-      <ConsolePanel text={consoleText} />
+      <ConsolePanel messages={consoleMessages} />
     </TabWidget>
   );
 };

--- a/gui/src/app/areas/ControlArea/SamplingArea/ResultsArea/SamplerOutputArea/ConsolePanel.tsx
+++ b/gui/src/app/areas/ControlArea/SamplingArea/ResultsArea/SamplerOutputArea/ConsolePanel.tsx
@@ -1,16 +1,25 @@
 import Box from "@mui/material/Box";
+import type { ConsoleMessage } from "@SpCore/StanSampler/SamplerTypes";
 
 import { FunctionComponent } from "react";
 
 type ConsoleProps = {
-  text: string;
+  messages: ConsoleMessage[];
 };
 
-const ConsolePanel: FunctionComponent<ConsoleProps> = ({ text }) => {
+const ConsolePanel: FunctionComponent<ConsoleProps> = ({ messages }) => {
   return (
-    <Box className="stdout" color="info.dark">
-      <pre>{text}</pre>
-    </Box>
+    <>
+      {messages.map((msg, index) => (
+        <Box
+          key={index}
+          className="stdout"
+          color={msg.type === "error" ? "error.main" : "info.dark"}
+        >
+          <pre>{msg.text}</pre>
+        </Box>
+      ))}
+    </>
   );
 };
 

--- a/gui/src/app/core/StanSampler/SamplerTypes.ts
+++ b/gui/src/app/core/StanSampler/SamplerTypes.ts
@@ -27,6 +27,11 @@ export enum Replies {
   Progress = "progress",
 }
 
+export type ConsoleMessage = {
+  text: string;
+  type: "error" | "log";
+};
+
 export type StanModelReplyMessage =
   | {
       purpose: Replies.ModelLoaded;
@@ -40,7 +45,7 @@ export type StanModelReplyMessage =
       draws: number[][];
       paramNames: string[];
       error: null;
-      consoleText: string;
+      consoleMessages: ConsoleMessage[];
       sampleConfig: SampleConfig;
     }
   | {
@@ -65,7 +70,7 @@ export type StanSamplerStatus =
   | "failed";
 
 export type StanRun = {
-  consoleText: string;
+  consoleMessages: ConsoleMessage[];
   draws: number[][];
   paramNames: string[];
   computeTimeSec: number;

--- a/gui/src/app/core/StanSampler/StanSampler.ts
+++ b/gui/src/app/core/StanSampler/StanSampler.ts
@@ -69,7 +69,7 @@ class StanSampler {
               paramNames: e.data.paramNames,
               computeTimeSec:
                 performance.now() / 1000 - this.#samplingStartTimeSec,
-              consoleText: e.data.consoleText,
+              consoleMessages: e.data.consoleMessages,
               sampleConfig: e.data.sampleConfig,
             });
           }

--- a/gui/src/app/core/StanSampler/useStanSampler.ts
+++ b/gui/src/app/core/StanSampler/useStanSampler.ts
@@ -2,6 +2,7 @@ import { useEffect, useReducer, useState } from "react";
 
 import { unreachable } from "@SpUtil/unreachable";
 import {
+  ConsoleMessage,
   Progress,
   SampleConfig,
   SamplerState,
@@ -33,7 +34,7 @@ export type SamplerStateAction =
       draws: number[][];
       paramNames: string[];
       computeTimeSec: number;
-      consoleText: string;
+      consoleMessages: ConsoleMessage[];
       sampleConfig: SampleConfig;
     };
 
@@ -68,7 +69,7 @@ const SamplerStateReducer = (
           paramNames: action.paramNames,
           computeTimeSec: action.computeTimeSec,
           sampleConfig: action.sampleConfig,
-          consoleText: action.consoleText,
+          consoleMessages: action.consoleMessages,
         },
       };
     default:

--- a/gui/yarn.lock
+++ b/gui/yarn.lock
@@ -4316,10 +4316,10 @@ tinyspy@^3.0.2:
   resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-3.0.2.tgz#86dd3cf3d737b15adcf17d7887c84a75201df20a"
   integrity sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==
 
-tinystan@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/tinystan/-/tinystan-0.3.1.tgz#9fb36b4ff998925791aafe419a84d94971208200"
-  integrity sha512-AU95Ub8IQt4C90uwnVWAyEBfjyl35bF6rdfeep2xSuadbY/ap1v+sU3YglcTV24f/XDm3mOkm24g3kRcZs8H0Q==
+tinystan@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/tinystan/-/tinystan-0.3.2.tgz#6b823dae25dcea6359e3aed64f2f0afc69dea721"
+  integrity sha512-PSqQJ0+wztxGJGEkHYx5jJGZZGWEZpOAZvCxuu3srmO26lM1CEn8uY4aQQzOPX0htmyxstrBFqEW6ZjF3eM5/Q==
 
 tldts-core@^6.1.86:
   version "6.1.86"


### PR DESCRIPTION
This updates the 'Console' output tab so it also shows warnings. For example, if you make the lotka-voltera example harder to initialize by setting init radius to 4, the current code doesn't tell you of any divergences (though `<F12>` will):

<img width="2857" height="1071" alt="image" src="https://github.com/user-attachments/assets/b87120df-338a-4959-ac99-308310ce237b" />


In this PR, those warnings are now included in the tab:

<img width="2857" height="1071" alt="image" src="https://github.com/user-attachments/assets/0c33c631-4019-40fe-9cdf-e98dc958393b" />


This required a small code change in tinystan's JS wrappers, hence the bump to 0.3.2