### PR TITLE
Remove brms-shimmed variables from global environment at start of run

### DIFF
--- a/gui/src/app/core/Scripting/webR/webR_preamble.R
+++ b/gui/src/app/core/Scripting/webR/webR_preamble.R
@@ -2,3 +2,8 @@
 webr::shim_install()
 # enable the canvas backend for plotting
 webr::canvas()
+
+# cleanliness -- brms shim modifies persistent environment, clean that up
+if (exists(".SP_CODE")) {
+  remove(".SP_CODE", "data", envir = .GlobalEnv)
+}


### PR DESCRIPTION
This fixes a subtle bug in data generation:

1. Run the brms data generation example
2. Manually edit the model, and remove the brms call from data generation
3. Re-run data generation. Observe that, unexpectedly, the model code is updated.