### PR TITLE
Version bumps

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile
-FROM emscripten/emsdk:4.0.21 AS builder
+FROM emscripten/emsdk:6.0.0 AS builder
 
 # Set the working directory
 WORKDIR /app
@@ -26,7 +26,7 @@ RUN mkdir oneTBB/build && cd oneTBB/build && \
     -DTBB_STRICT=OFF \
     -DCMAKE_CXX_FLAGS="-fwasm-exceptions -Wno-unused-command-line-argument" \
     -DTBB_DISABLE_HWLOC_AUTOMATIC_SEARCH=ON \
-    -DBUILD_SHARED_LIBS=ON \
+    -DBUILD_SHARED_LIBS=OFF \
     -DTBB_EXAMPLES=OFF \
     -DTBB_TEST=OFF \
     -DEMSCRIPTEN_WITHOUT_PTHREAD=true \
@@ -35,8 +35,8 @@ RUN mkdir oneTBB/build && cd oneTBB/build && \
     cmake --install .
 
 # Install Python dependencies
-RUN pip install fastapi[all]
-RUN pip install uvicorn
+RUN pip install --break-system-packages fastapi[all]
+RUN pip install --break-system-packages uvicorn
 
 # Clone the TinyStan repository and checkout a specific commit
 RUN git clone https://github.com/WardBrian/tinystan.git && \

--- a/backend/local.mk
+++ b/backend/local.mk
@@ -12,9 +12,9 @@ LDLIBS_TBB ?= -ltbb
 TINYSTAN_SERIAL=true
 
 # could also uses -fexceptions which is more compatible, but slower
-CXXFLAGS+=-fwasm-exceptions
+CXXFLAGS+=-fwasm-exceptions # -sWASM_LEGACY_EXCEPTIONS=false
 
-LDFLAGS+=-sMODULARIZE -sEXPORT_NAME=createModule -sEXPORT_ES6 -sENVIRONMENT=web,worker -sINCOMING_MODULE_JS_API=print,printErr
+LDFLAGS+=-sMODULARIZE -sFAKE_DYLIBS -sEXPORT_NAME=createModule -sEXPORT_ES6 -sENVIRONMENT=web,worker -sINCOMING_MODULE_JS_API=print,printErr
 LDFLAGS+=-sEXIT_RUNTIME=1 -sALLOW_MEMORY_GROWTH=1
 # Functions we want. Can add more, with a prepended _, from tinystan.h
 EXPORTS=_malloc,_free,_tinystan_api_version,_tinystan_create_model,_tinystan_destroy_error,_tinystan_destroy_model,_tinystan_get_error_message,_tinystan_get_error_type,_tinystan_model_num_free_params,_tinystan_model_param_names,_tinystan_sample,_tinystan_separator_char,_tinystan_stan_version

--- a/gui/package.json
+++ b/gui/package.json
@@ -33,7 +33,7 @@
     "lz-string": "^1.5.0",
     "mcmc-stats": "^0.0.1",
     "plotly-stan-playground-dist": "file:./vendor/plotly-stan-playground-dist",
-    "pyodide": "^0.29.0",
+    "pyodide": "^314.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-dropzone": "^14.3.5",

--- a/gui/src/app/core/Scripting/pyodide/pyodideWorker.ts
+++ b/gui/src/app/core/Scripting/pyodide/pyodideWorker.ts
@@ -12,7 +12,7 @@ import { File } from "@SpUtil/files";
 
 const loadPyodideInstance = async () => {
   const pyodide = await loadPyodide({
-    indexURL: "https://cdn.jsdelivr.net/pyodide/v0.29.0/full",
+    indexURL: "https://cdn.jsdelivr.net/pyodide/v314.0.0/full",
     stdout: (x: string) => {
       sendStdout(x);
     },
@@ -117,9 +117,7 @@ const run = async (
       }
       if (script.includes("requests") || script.includes("https://")) {
         patch_http = true;
-        setUpPromises.push(
-          micropip.install(["requests", "lzma", "pyodide-http"]),
-        );
+        setUpPromises.push(micropip.install(["requests", "pyodide-http"]));
       }
       setUpPromises.push(micropip.install("stanio"));
       setUpPromises.push(pyodide.loadPackagesFromImports(script));

--- a/gui/yarn.lock
+++ b/gui/yarn.lock
@@ -3536,10 +3536,10 @@ punycode@^2.1.0, punycode@^2.3.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
-pyodide@^0.29.0:
-  version "0.29.0"
-  resolved "https://registry.yarnpkg.com/pyodide/-/pyodide-0.29.0.tgz#c57be81c09ea5a7c2eae9449c22d506c399e910a"
-  integrity sha512-ObIvsTmcrxAWKg+FT1GjfSdDmQc5CabnYe/nn5BCuhr9BVVITeQ24DBdZuG5B2tIiAZ9YonBpnDB7cmHZyd2Rw==
+pyodide@^314.0.0:
+  version "314.0.0"
+  resolved "https://registry.yarnpkg.com/pyodide/-/pyodide-314.0.0.tgz#a005ac1a733fd21cb778b666b5a8b714c201c679"
+  integrity sha512-WIofRQehY78IC9n3+p9COjKUZGCCHfrvtR5dXKm0BHIWUun2B8DBf17rXytMF/KYkrsDQRa+BDGhi8UKwzaU3w==
   dependencies:
     "@types/emscripten" "^1.41.4"
     ws "^8.5.0"


### PR DESCRIPTION
Major versions have recently released of pyodide and emscripten.

The only breaking changes that affected us is that emscripten changed the default value of `FAKE_DYLIBS`, and pyodide now includes `lzma` by default.


How to verify:

- Run local compilation server, build examples
- Run data and analysis.py for disease transmission example