### PR TITLE
Use development version of Monaco editor

### DIFF
--- a/gui/package.json
+++ b/gui/package.json
@@ -63,7 +63,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "globals": "^17.3.0",
     "jsdom": "^26.1.0",
-    "monaco-editor": "^0.55.1",
+    "monaco-editor": "v0.56.0-dev-20260625",
     "prettier": "^3.3.2",
     "typescript": "^6.0.2",
     "typescript-eslint": "^8.59.0",

--- a/gui/src/app/components/FileEditor/TextEditor.tsx
+++ b/gui/src/app/components/FileEditor/TextEditor.tsx
@@ -23,7 +23,7 @@ import monacoAddStanLang from "./monacoStanLanguage";
 // to avoid downloading twice.
 loader.config({
   paths: {
-    vs: "https://cdn.jsdelivr.net/npm/monaco-editor@0.55.1/min/vs",
+    vs: "https://cdn.jsdelivr.net/npm/monaco-editor@v0.56.0-dev-20260625/min/vs",
   },
 });
 loader.init().then(monacoAddStanLang);

--- a/gui/yarn.lock
+++ b/gui/yarn.lock
@@ -2076,10 +2076,10 @@ dom-helpers@^5.0.1:
     "@babel/runtime" "^7.8.7"
     csstype "^3.0.2"
 
-dompurify@3.2.7:
-  version "3.2.7"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.2.7.tgz#721d63913db5111dd6dfda8d3a748cfd7982d44a"
-  integrity sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==
+dompurify@3.4.8:
+  version "3.4.8"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.8.tgz#6c54f8c207160e7f83fcb7f4fd05a82ac36b1cdc"
+  integrity sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 
@@ -3307,12 +3307,12 @@ minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-monaco-editor@^0.55.1:
-  version "0.55.1"
-  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.55.1.tgz#e74c6fe5a6bf985b817d2de3eb88d56afc494a1b"
-  integrity sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==
+monaco-editor@v0.56.0-dev-20260625:
+  version "0.56.0-dev-20260625"
+  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.56.0-dev-20260625.tgz#cbee6892f398efd036ac1a85ce89e9d59debd8dd"
+  integrity sha512-3AMaHDh0uUmy/Pb2lcm9qHtIBU15M7MLwld9SNOPuEJOsWO2X/xipAA4XdZ1sPtGBMtE1LqD7Ca93rl5JfyVGw==
   dependencies:
-    dompurify "3.2.7"
+    dompurify "3.4.8"
     marked "14.0.0"
 
 ms@^2.1.3:


### PR DESCRIPTION
It's been a while since monaco has had a true release. This would silence the bunch of dependabot warnings about dompurify 